### PR TITLE
The minimum coverage key must be a double.

### DIFF
--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -14,7 +14,7 @@ class ScoverageSbtPlugin extends sbt.Plugin {
 
   object ScoverageKeys {
     val excludedPackages = SettingKey[String]("scoverage-excluded-packages")
-    val minimumCoverage = SettingKey[Int]("scoverage-minimum-coverage")
+    val minimumCoverage = SettingKey[Double]("scoverage-minimum-coverage")
     val failOnMinimumCoverage = SettingKey[Boolean]("scoverage-fail-on-minimum-coverage")
     val highlighting = SettingKey[Boolean]("scoverage-highlighting", "enables range positioning for highlighting")
   }


### PR DESCRIPTION
When I run the the coverage I get an error like this:

[error] [scoverage] Coverage is below minimum [99.46% < 99%]

I believe because it is treating the code coverage minimum like a Int in the comparison so this statement is false.
