### PR TITLE
Error comparing statement-coverage to min percent value

### DIFF
--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -144,7 +144,7 @@ class ScoverageSbtPlugin extends sbt.Plugin {
 
               // check for default minimum
               if (min > 0) {
-                if (min > coverage.statementCoverage) {
+                if (min > coverage.statementCoveragePercent) {
                   s.log.error(s"[scoverage] Coverage is below minimum [${coverage.statementCoverageFormatted}% < $min%]")
                   if (failOnMin)
                     throw new RuntimeException("Coverage minimum was not reached")


### PR DESCRIPTION
When I run the the coverage with fail on minimum the build always fails:

[error] [scoverage] Coverage is below minimum [89.81% < 80.0%]

The min value is a percent value and is compared to the wrong coverage value.
