### PR TITLE
Exclude classes and packages with ScoverageCompile

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ regular expressions.
 
 Example:
 ```scala
-ScoverageKeys.excludedPackages in scoverageTest := "<empty>;Reverse.*;.*AuthService.*;models\.data\..*"
+ScoverageKeys.excludedPackages in ScoverageCompile := "<empty>;Reverse.*;.*AuthService.*;models\.data\..*"
 ```
 
 The regular expressions are matched against the fully qualified class name, and must match the entire string to take effect.


### PR DESCRIPTION
`scoverageTest` is wrong -> it should be `ScoverageTest`
But with `ScoverageTest` it does not work.
Using `ScoverageCompile` enable the exclusions.
