### PR TITLE
Coverage off

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: scala
 
+script: sbt ++$TRAVIS_SCALA_VERSION test scripted
+
 after_script:
   - if [[ $TRAVIS_TEST_RESULT == 0 && "$TRAVIS_BRANCH" == "master" ]]; then sbt "^publish"; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: scala
 script: sbt ++$TRAVIS_SCALA_VERSION test scripted
 
 after_script:
-  - if [[ $TRAVIS_TEST_RESULT == 0 && "$TRAVIS_BRANCH" == "master" ]]; then sbt "^publish"; fi
+  - if [[ $TRAVIS_TEST_RESULT == 0 && 
+          "$TRAVIS_REPO_SLUG" == "scoverage/sbt-scoverage" &&
+          "$TRAVIS_BRANCH" == "master" ]]; then sbt "^publish"; fi
 
 scala:
   - "2.10.4"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ $ sbt coverageReport
 
 to generate the reports. You will find the coverage reports inside `target/scoverage-report`. There are HTML and XML reports. The XML is useful if you need to programatically use the results, or if you're writing a tool.
 
+If you're running the coverage reports from within an sbt console session (as
+opposed to one command per sbt launch), then the `coverage` task is sticky. To
+turn it back off when you're done running reports, use the `coverageOff` task.
+
 If you want to see a project that is already setup to use scoverage in both sbt and maven, then clone [the scoverage samples project](https://github.com/scoverage/scoverage-samples).
 
 ## Notes on upgrading to version 1.0.0

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "sbt-scoverage"
 
 organization := "org.scoverage"
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.10.5"
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-feature", "-encoding", "utf8")
 
@@ -16,7 +16,7 @@ resolvers <++= isSnapshot(
 )
 
 libraryDependencies ++= Seq(
-  "org.scoverage" %% "scalac-scoverage-plugin" % "1.0.5-SNAPSHOT"
+  "org.scoverage" %% "scalac-scoverage-plugin" % "1.1.0"
 )
 
 publishTo := {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.7

--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -15,6 +15,7 @@ class ScoverageSbtPlugin extends sbt.AutoPlugin {
 
   object ScoverageKeys {
     lazy val coverage = taskKey[Unit]("enable compiled code with instrumentation")
+    lazy val coverageOff = taskKey[Unit]("disable compiled code with instrumentation")
     lazy val coverageReport = taskKey[Unit]("run report generation")
     lazy val coverageAggregate = taskKey[Unit]("aggregate reports from subprojects")
     val coverageExcludedPackages = settingKey[String]("regex for excluded packages")
@@ -40,6 +41,10 @@ class ScoverageSbtPlugin extends sbt.AutoPlugin {
 
     coverage := {
       enabled = true
+    },
+
+    coverageOff := {
+      enabled = false
     },
 
     coverageReport := {

--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -11,7 +11,7 @@ class ScoverageSbtPlugin extends sbt.AutoPlugin {
   val OrgScoverage = "org.scoverage"
   val ScalacRuntimeArtifact = "scalac-scoverage-runtime"
   val ScalacPluginArtifact = "scalac-scoverage-plugin"
-  val ScoverageVersion = "1.0.5-SNAPSHOT"
+  val ScoverageVersion = "1.1.0"
 
   object ScoverageKeys {
     lazy val coverage = taskKey[Unit]("enable compiled code with instrumentation")

--- a/src/sbt-test/scoverage/bad-coverage/build.sbt
+++ b/src/sbt-test/scoverage/bad-coverage/build.sbt
@@ -4,8 +4,6 @@ scalaVersion := "2.10.4"
 
 libraryDependencies += "org.specs2" %% "specs2" % "2.3.13" % "test"
 
-instrumentSettings
+ScoverageSbtPlugin.ScoverageKeys.coverageMinimum := 80
 
-ScoverageKeys.minimumCoverage := 80
-
-ScoverageKeys.failOnMinimumCoverage := true
+ScoverageSbtPlugin.ScoverageKeys.coverageFailOnMinimum := true

--- a/src/sbt-test/scoverage/bad-coverage/test
+++ b/src/sbt-test/scoverage/bad-coverage/test
@@ -1,3 +1,4 @@
 # run scoverage
 > clean
--> scoverage:test
+> coverage
+-> test

--- a/src/sbt-test/scoverage/coverage-off/build.sbt
+++ b/src/sbt-test/scoverage/coverage-off/build.sbt
@@ -1,0 +1,9 @@
+version := "0.1"
+
+scalaVersion := "2.10.4"
+
+libraryDependencies += "org.specs2" %% "specs2" % "2.3.13" % "test"
+
+ScoverageSbtPlugin.ScoverageKeys.coverageMinimum := 80
+
+ScoverageSbtPlugin.ScoverageKeys.coverageFailOnMinimum := true

--- a/src/sbt-test/scoverage/coverage-off/project/plugins.sbt
+++ b/src/sbt-test/scoverage/coverage-off/project/plugins.sbt
@@ -1,0 +1,15 @@
+// The Typesafe repository
+resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+
+//scoverage needs this
+resolvers += Classpaths.sbtPluginReleases
+
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                 |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("org.scoverage" %% "sbt-scoverage" % pluginVersion)
+}
+
+

--- a/src/sbt-test/scoverage/coverage-off/src/main/scala/GoodCoverage.scala
+++ b/src/sbt-test/scoverage/coverage-off/src/main/scala/GoodCoverage.scala
@@ -1,0 +1,6 @@
+object GoodCoverage {
+
+  def sum(num1: Int, num2: Int) = {
+    num1 + num2
+  }
+}

--- a/src/sbt-test/scoverage/coverage-off/src/test/scala/GoodCoverageSpec.scala
+++ b/src/sbt-test/scoverage/coverage-off/src/test/scala/GoodCoverageSpec.scala
@@ -1,0 +1,13 @@
+import org.specs2.mutable._
+
+/**
+ * Created by tbarke001c on 7/8/14.
+ */
+class GoodCoverageSpec extends Specification {
+
+  "GoodCoverage" should {
+    "sum two numbers" in {
+      GoodCoverage.sum(1, 2) mustEqual 3
+    }
+  }
+}

--- a/src/sbt-test/scoverage/coverage-off/test
+++ b/src/sbt-test/scoverage/coverage-off/test
@@ -1,0 +1,10 @@
+# run scoverage using the coverage task
+> clean
+> coverage
+> test
+# turn off coverage using the coverage-off task and recompile
+> clean
+> coverageOff
+> test
+# There should be no scoverage-data directory
+-$ exists target/scala-2.10/scoverage-data

--- a/src/sbt-test/scoverage/good-coverage/build.sbt
+++ b/src/sbt-test/scoverage/good-coverage/build.sbt
@@ -4,8 +4,6 @@ scalaVersion := "2.10.4"
 
 libraryDependencies += "org.specs2" %% "specs2" % "2.3.13" % "test"
 
-instrumentSettings
+ScoverageSbtPlugin.ScoverageKeys.coverageMinimum := 80
 
-ScoverageKeys.minimumCoverage := 80
-
-ScoverageKeys.failOnMinimumCoverage := true
+ScoverageSbtPlugin.ScoverageKeys.coverageFailOnMinimum := true

--- a/src/sbt-test/scoverage/good-coverage/test
+++ b/src/sbt-test/scoverage/good-coverage/test
@@ -1,3 +1,4 @@
 # run scoverage
 > clean
-> scoverage:test
+> coverage
+> test

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.0"
+version in ThisBuild := "1.2.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.5-SNAPSHOT"
+version in ThisBuild := "1.1.0"


### PR DESCRIPTION
Closes #109.

Note that in addition to adding a `coverageOff` task, this patch merges master with the 1.1.0 release and fixes the scripted sbt tests. It also bumps the version to 1.2.0-SNAPSHOT and adds the scripted tests to the travis configuration. I can pretty easily split the other stuff out if you'd prefer a more focused patch.