### PR TITLE
Use fully-qualified class names to avoid ambiguity in reports

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ resolvers ++= {
   else Seq.empty
 }
 
-libraryDependencies += "org.scoverage" %% "scalac-scoverage-plugin" % "1.1.1"
+libraryDependencies += "org.scoverage" %% "scalac-scoverage-plugin" % "1.2.0"
 
 publishMavenStyle := true
 

--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -10,7 +10,7 @@ object ScoverageSbtPlugin extends AutoPlugin {
   val OrgScoverage = "org.scoverage"
   val ScalacRuntimeArtifact = "scalac-scoverage-runtime"
   val ScalacPluginArtifact = "scalac-scoverage-plugin"
-  val ScoverageVersion = "1.1.1"
+  val ScoverageVersion = "1.2.0"
   val autoImport = ScoverageKeys
 
   import autoImport._

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.3.4"
+version in ThisBuild := "1.3.5"


### PR DESCRIPTION
(Fixes https://github.com/scoverage/scalac-scoverage-plugin/issues/27)

(Conflicts with #133 only in the version numbers, I think. Both PRs need a `sbt-scoverage` version number increment. I have chosen different version numbers for the two PRs to avoid confusion.)