### PR TITLE
proper test coverageAggregate

### DIFF
--- a/src/sbt-test/scoverage/aggregate/build.sbt
+++ b/src/sbt-test/scoverage/aggregate/build.sbt
@@ -1,8 +1,6 @@
 /*
   The projects test aggregation of coverage reports from two sub-projects.
-  The sub-projects are in the irectories partA and partB.
-  The tests are against the sources of ScoverageSbtPlugin in the parent directory.
-  It might be possible to test other versions of ScoverageSbtPlugin.
+  The sub-projects are in the directories partA and partB.
 */
 
 lazy val commonSettings = Seq(
@@ -35,6 +33,3 @@ lazy val root = (project in file("."))
     partA,
     partB
   )
-
-
-

--- a/src/sbt-test/scoverage/aggregate/project/plugins.sbt
+++ b/src/sbt-test/scoverage/aggregate/project/plugins.sbt
@@ -1,6 +1,15 @@
-/*
- * ScoveragePlugin is constructed from the sources in the parent directory
- */
-lazy val root = (project in file(".")).dependsOn(scoveragePlugin)
+// The Typesafe repository
+resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-lazy val scoveragePlugin = file("../../../..").getAbsoluteFile.toURI
+//scoverage needs this
+resolvers += Classpaths.sbtPluginReleases
+
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                 |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("org.scoverage" %% "sbt-scoverage" % pluginVersion)
+}
+
+

--- a/src/sbt-test/scoverage/aggregate/test
+++ b/src/sbt-test/scoverage/aggregate/test
@@ -1,2 +1,10 @@
-#this file is necessary for scripted plugin. See http://eed3si9n.com/testing-sbt-plugins
-#it is empty for now
+# run scoverage using the coverage task
+> clean
+> coverage
+> test
+# There should be scoverage-data directory
+$ exists partA/target/scala-2.10/scoverage-data
+$ exists partB/target/scala-2.10/scoverage-data
+> coverageAggregate
+# There should be scoverage-data directory
+$ exists target/scala-2.10/scoverage-report

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.3.3"
+version in ThisBuild := "1.3.4"


### PR DESCRIPTION
This enables testing multiproject and `coverageAggregate` task. This would help detect issues fixed in #129 early.

Have to bump the version number so the dev version gets picked up rather than the released version. Let  me know if you prefer another version number.