### PR TITLE
sbt-test to verify that scala.js is supported by scoverage

### DIFF
--- a/src/sbt-test/scoverage/scalajs/build.sbt
+++ b/src/sbt-test/scoverage/scalajs/build.sbt
@@ -1,0 +1,12 @@
+lazy val root = (project in file(".")).aggregate(crossJS, crossJVM)
+
+lazy val cross = crossProject.in(file("sjstest")).settings(
+    scalaVersion := "2.11.7",
+    libraryDependencies ++= Seq(
+      "org.scalatest" %%% "scalatest" % "3.0.0-M15" % "test"
+    )
+  )
+
+
+lazy val crossJS = cross.js
+lazy val crossJVM = cross.jvm

--- a/src/sbt-test/scoverage/scalajs/project/plugins.sbt
+++ b/src/sbt-test/scoverage/scalajs/project/plugins.sbt
@@ -1,0 +1,15 @@
+// The Typesafe repository
+resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+
+//scoverage needs this
+resolvers += Classpaths.sbtPluginReleases
+
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                 |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("org.scoverage" %% "sbt-scoverage" % pluginVersion)
+}
+
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.8")

--- a/src/sbt-test/scoverage/scalajs/sjstest/js/src/test/scala/JsTest.scala
+++ b/src/sbt-test/scoverage/scalajs/sjstest/js/src/test/scala/JsTest.scala
@@ -1,0 +1,10 @@
+import org.scalatest.{FlatSpec, Matchers}
+
+class JsTest extends FlatSpec with Matchers {
+
+  "JS UnderTest" should "work on JS" in {
+    UnderTest.jsMethod shouldBe "js"
+  }
+
+}
+

--- a/src/sbt-test/scoverage/scalajs/sjstest/jvm/src/test/scala/JvmTest.scala
+++ b/src/sbt-test/scoverage/scalajs/sjstest/jvm/src/test/scala/JvmTest.scala
@@ -1,0 +1,10 @@
+import org.scalatest.{FlatSpec, Matchers}
+
+class JvmTest extends FlatSpec with Matchers {
+
+  "JVM UnderTest" should "work on JVM" in {
+    UnderTest.jvmMethod shouldBe "jvm"
+  }
+
+}
+

--- a/src/sbt-test/scoverage/scalajs/sjstest/shared/src/main/scala/UnderTest.scala
+++ b/src/sbt-test/scoverage/scalajs/sjstest/shared/src/main/scala/UnderTest.scala
@@ -1,0 +1,8 @@
+
+object UnderTest {
+  def onJsAndJvm: String = "js and jvm"
+
+  def jsMethod: String = "js"
+
+  def jvmMethod: String = "jvm"
+}

--- a/src/sbt-test/scoverage/scalajs/sjstest/shared/src/test/scala/SharedTest.scala
+++ b/src/sbt-test/scoverage/scalajs/sjstest/shared/src/test/scala/SharedTest.scala
@@ -1,0 +1,9 @@
+import org.scalatest.{FlatSpec, Matchers}
+
+class SharedTest extends FlatSpec with Matchers {
+
+  "Shared UnderTest" should "return where it works" in {
+    UnderTest.onJsAndJvm shouldBe "js and jvm"
+  }
+
+}

--- a/src/sbt-test/scoverage/scalajs/test
+++ b/src/sbt-test/scoverage/scalajs/test
@@ -1,0 +1,11 @@
+# run scoverage using the coverage task
+> clean
+> coverage
+> test
+# There should be scoverage-data directory
+$ exists sjstest/js/target/scala-2.11/scoverage-data
+$ exists sjstest/jvm/target/scala-2.11/scoverage-data
+> coverageReport
+# There should be scoverage-report directory
+$ exists sjstest/js/target/scala-2.11/scoverage-report
+$ exists sjstest/jvm/target/scala-2.11/scoverage-report


### PR DESCRIPTION
This is a follow up to https://github.com/scoverage/sbt-scoverage/pull/166 and scala.js support in scalac-scoverage-plugin