### PR TITLE
Using coverage/coverageOff  preserves settings overrides

### DIFF
--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -49,6 +49,7 @@ object ScoverageSbtPlugin extends AutoPlugin {
     */
   private def toggleCoverage(status: Boolean): State => State = { state =>
     val extracted = Project.extract(state)
+    val currentProjRef = extracted.currentRef
     val newSettings = extracted.structure.allProjectRefs flatMap { proj =>
       Seq(
         coverageEnabled in proj := status,
@@ -60,7 +61,9 @@ object ScoverageSbtPlugin extends AutoPlugin {
         }
       )
     }
-    extracted.append(newSettings, state)
+    val appendSettings = Load.transformSettings(Load.projectScope(currentProjRef), currentProjRef.build, extracted.rootProject, newSettings)
+    val newSessionSettings = extracted.session.appendRaw(appendSettings)
+    SessionSettings.reapply(newSessionSettings, state)
   }
 
   private lazy val coverageReport0 = Def.task {

--- a/src/sbt-test/scoverage/aggregate/test
+++ b/src/sbt-test/scoverage/aggregate/test
@@ -5,6 +5,10 @@
 # There should be scoverage-data directory
 $ exists partA/target/scala-2.10/scoverage-data
 $ exists partB/target/scala-2.10/scoverage-data
+> coverageReport
+# There should be scoverage-report directory
+$ exists partA/target/scala-2.10/scoverage-report
+$ exists partB/target/scala-2.10/scoverage-report
 > coverageAggregate
-# There should be scoverage-data directory
+# There should be a root scoverage-report directory
 $ exists target/scala-2.10/scoverage-report

--- a/src/sbt-test/scoverage/preserve-set/build.sbt
+++ b/src/sbt-test/scoverage/preserve-set/build.sbt
@@ -1,0 +1,14 @@
+import sbt.complete.DefaultParsers._
+
+version := "0.1"
+
+scalaVersion := "2.10.4"
+
+libraryDependencies += "org.specs2" %% "specs2" % "2.3.13" % "test"
+
+val checkScalaVersion = inputKey[Unit]("Input task to compare the value of scalaVersion setting with a given input.")
+checkScalaVersion := {
+  val arg: String = (Space ~> StringBasic).parsed
+  if (scalaVersion.value != arg) error(s"scalaVersion [${scalaVersion.value}] not equal to expected [$arg]")
+  ()
+}

--- a/src/sbt-test/scoverage/preserve-set/project/plugins.sbt
+++ b/src/sbt-test/scoverage/preserve-set/project/plugins.sbt
@@ -1,0 +1,15 @@
+// The Typesafe repository
+resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+
+//scoverage needs this
+resolvers += Classpaths.sbtPluginReleases
+
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                 |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("org.scoverage" %% "sbt-scoverage" % pluginVersion)
+}
+
+

--- a/src/sbt-test/scoverage/preserve-set/src/main/scala/PreserveSet.scala
+++ b/src/sbt-test/scoverage/preserve-set/src/main/scala/PreserveSet.scala
@@ -1,0 +1,6 @@
+object PreserveSet {
+
+  def sum(num1: Int, num2: Int) = {
+    num1 + num2
+  }
+}

--- a/src/sbt-test/scoverage/preserve-set/src/test/scala/PreserveSetSpec.scala
+++ b/src/sbt-test/scoverage/preserve-set/src/test/scala/PreserveSetSpec.scala
@@ -1,0 +1,10 @@
+import org.specs2.mutable._
+
+class PreserveSetSpec extends Specification {
+
+  "PreserveSet" should {
+    "sum two numbers" in {
+      PreserveSet.sum(1, 2) mustEqual 3
+    }
+  }
+}

--- a/src/sbt-test/scoverage/preserve-set/test
+++ b/src/sbt-test/scoverage/preserve-set/test
@@ -1,0 +1,11 @@
+# check scalaVersion setting
+> checkScalaVersion "2.10.4"
+# override scalaVersion setting
+> set scalaVersion := {"2.10.5"}
+> checkScalaVersion "2.10.5"
+# activate coverage - override should still be present
+> coverage
+> checkScalaVersion "2.10.5"
+# turn off coverage - override should still be present
+> coverageOff
+> checkScalaVersion "2.10.5"


### PR DESCRIPTION
Hi,

This PR addresses the issue #146 .
The problem was that the method `Extracted.append` actually drops the settings that were added with the `set` command.
You can see it here: https://github.com/sbt/sbt/blob/1.0.x/main/src/main/scala/sbt/Extracted.scala#L105
`session.original` is used instead of `session.mergeSettings` .

Instead of using `Extracted.append` I used `SessionSettings.reapply`.

I added a scripted test to check that `coverage` and `coverageOff` do not reset settings set with `set`.

When running the scripted tests, aggregate was failing because a call to `coverageReport` was missing (according to https://github.com/scoverage/sbt-scoverage#multi-project-reports).
Also, coverage-off is failing because of https://github.com/scoverage/sbt-scoverage/commit/0f9496df5ceae823ad86452c6f1afabf4f73ded0 , but it should be fixed by PR #166 or PR #168.
