### PR TITLE
Avoid removing settings overrides done during the session when executing toggleCoverage

### DIFF
--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -58,9 +58,13 @@ object ScoverageSbtPlugin extends AutoPlugin {
     */
   private def toggleCoverage(status: Boolean): State => State = { state =>
     val extracted = Project.extract(state)
+    val currentProjRef = extracted.currentRef
     val newSettings = extracted.structure.allProjectRefs.flatMap(proj =>
-      Seq(coverageEnabled in proj := status))
-    extracted.append(newSettings, state)
+      Seq(coverageEnabled in proj := status)
+    )
+    val appendSettings = Load.transformSettings(Load.projectScope(currentProjRef), currentProjRef.build, extracted.rootProject, newSettings)
+    val newSessionSettings = extracted.session.appendRaw(appendSettings)
+    SessionSettings.reapply(newSessionSettings, state)
   }
 
   // returns "_sjs$sjsVersion" for Scala.js projects or "" otherwise

--- a/src/sbt-test/scoverage/preserve-set/build.sbt
+++ b/src/sbt-test/scoverage/preserve-set/build.sbt
@@ -1,0 +1,19 @@
+import sbt.complete.DefaultParsers._
+
+version := "0.1"
+
+scalaVersion := "2.10.4"
+
+libraryDependencies += "org.specs2" %% "specs2" % "2.3.13" % "test"
+
+val checkScalaVersion = inputKey[Unit]("Input task to compare the value of scalaVersion setting with a given input.")
+checkScalaVersion := {
+  val arg: String = (Space ~> StringBasic).parsed
+  if (scalaVersion.value != arg) error(s"scalaVersion [${scalaVersion.value}] not equal to expected [$arg]")
+  ()
+}
+
+resolvers ++= {
+  if (sys.props.get("plugin.version").map(_.endsWith("-SNAPSHOT")).getOrElse(false)) Seq(Resolver.sonatypeRepo("snapshots"))
+  else Seq.empty
+}

--- a/src/sbt-test/scoverage/preserve-set/project/plugins.sbt
+++ b/src/sbt-test/scoverage/preserve-set/project/plugins.sbt
@@ -1,0 +1,20 @@
+// The Typesafe repository
+resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+
+//scoverage needs this
+resolvers += Classpaths.sbtPluginReleases
+
+val pluginVersion = sys.props.getOrElse(
+  "plugin.version",
+  throw new RuntimeException(
+    """|The system property 'plugin.version' is not defined.
+       |Specify this property using the scriptedLaunchOpts -D.""".stripMargin))
+
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % pluginVersion)
+
+resolvers ++= {
+  if (pluginVersion.endsWith("-SNAPSHOT"))
+    Seq(Resolver.sonatypeRepo("snapshots"))
+  else
+    Seq.empty
+}

--- a/src/sbt-test/scoverage/preserve-set/src/main/scala/PreserveSet.scala
+++ b/src/sbt-test/scoverage/preserve-set/src/main/scala/PreserveSet.scala
@@ -1,0 +1,6 @@
+object PreserveSet {
+
+  def sum(num1: Int, num2: Int) = {
+    num1 + num2
+  }
+}

--- a/src/sbt-test/scoverage/preserve-set/src/test/scala/PreserveSetSpec.scala
+++ b/src/sbt-test/scoverage/preserve-set/src/test/scala/PreserveSetSpec.scala
@@ -1,0 +1,10 @@
+import org.specs2.mutable._
+
+class PreserveSetSpec extends Specification {
+
+  "PreserveSet" should {
+    "sum two numbers" in {
+      PreserveSet.sum(1, 2) mustEqual 3
+    }
+  }
+}

--- a/src/sbt-test/scoverage/preserve-set/test
+++ b/src/sbt-test/scoverage/preserve-set/test
@@ -1,0 +1,11 @@
+# check scalaVersion setting
+> checkScalaVersion "2.10.4"
+# override scalaVersion setting
+> set scalaVersion := {"2.10.5"}
+> checkScalaVersion "2.10.5"
+# activate coverage - override should still be present
+> coverage
+> checkScalaVersion "2.10.5"
+# turn off coverage - override should still be present
+> coverageOff
+> checkScalaVersion "2.10.5"


### PR DESCRIPTION
This is just a rebase of https://github.com/scoverage/sbt-scoverage/pull/175