### PR TITLE
Flag `coverageSkip` to exclude project from coverage generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ after_script:
 
 scala:
   - "2.10.6"
+jdk:
+  - oraclejdk8
 
 sudo: false
 before_cache:

--- a/src/main/scala/scoverage/ScoverageKeys.scala
+++ b/src/main/scala/scoverage/ScoverageKeys.scala
@@ -18,4 +18,5 @@ object ScoverageKeys {
   lazy val coverageCleanSubprojectFiles = settingKey[Boolean]("removes subproject data after an aggregation")
   lazy val coverageOutputTeamCity = settingKey[Boolean]("turn on teamcity reporting")
   lazy val coverageScalacPluginVersion = settingKey[String]("version of scalac-scoverage-plugin to use")
+  lazy val coverageSkip = settingKey[Boolean]("exclude project from coverage generation, it has priority over coverageEnabled setting and coverage command")
 }

--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -25,6 +25,7 @@ object ScoverageSbtPlugin extends AutoPlugin {
 
   override lazy val projectSettings = Seq(
     coverageEnabled := false,
+    coverageSkip := false,
     commands += Command.command("coverage", "enable compiled code with instrumentation", "")(toggleCoverage(true)),
     commands += Command.command("coverageOff", "disable compiled code with instrumentation", "")(toggleCoverage(false)),
     coverageReport <<= coverageReport0,
@@ -60,7 +61,7 @@ object ScoverageSbtPlugin extends AutoPlugin {
     val extracted = Project.extract(state)
     val currentProjRef = extracted.currentRef
     val newSettings = extracted.structure.allProjectRefs.flatMap(proj =>
-      Seq(coverageEnabled in proj := status)
+      Seq(coverageEnabled in proj := status && !(coverageSkip in proj).value )
     )
     val appendSettings = Load.transformSettings(Load.projectScope(currentProjRef), currentProjRef.build, extracted.rootProject, newSettings)
     val newSessionSettings = extracted.session.appendRaw(appendSettings)

--- a/src/sbt-test/scoverage/skip-scala-version/build.sbt
+++ b/src/sbt-test/scoverage/skip-scala-version/build.sbt
@@ -1,0 +1,21 @@
+import sbt.complete.DefaultParsers._
+
+version := "0.1"
+
+scalaVersion := "2.10.4"
+
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.0" % "test"
+
+coverageSkip := scalaVersion.value.startsWith("2.12")
+
+val checkScalaVersion = inputKey[Unit]("Input task to compare the value of scalaVersion setting with a given input.")
+checkScalaVersion := {
+  val arg: String = (Space ~> StringBasic).parsed
+  if (scalaVersion.value != arg) error(s"scalaVersion [${scalaVersion.value}] not equal to expected [$arg]")
+  ()
+}
+
+resolvers in ThisBuild ++= {
+  if (sys.props.get("plugin.version").map(_.endsWith("-SNAPSHOT")).getOrElse(false)) Seq(Resolver.sonatypeRepo("snapshots"))
+  else Seq.empty
+}

--- a/src/sbt-test/scoverage/skip-scala-version/project/plugins.sbt
+++ b/src/sbt-test/scoverage/skip-scala-version/project/plugins.sbt
@@ -1,0 +1,20 @@
+// The Typesafe repository
+resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+
+//scoverage needs this
+resolvers += Classpaths.sbtPluginReleases
+
+val pluginVersion = sys.props.getOrElse(
+  "plugin.version",
+  throw new RuntimeException(
+    """|The system property 'plugin.version' is not defined.
+       |Specify this property using the scriptedLaunchOpts -D.""".stripMargin))
+
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % pluginVersion)
+
+resolvers ++= {
+  if (pluginVersion.endsWith("-SNAPSHOT"))
+    Seq(Resolver.sonatypeRepo("snapshots"))
+  else
+    Seq.empty
+}

--- a/src/sbt-test/scoverage/skip-scala-version/src/main/scala/GoodCoverage.scala
+++ b/src/sbt-test/scoverage/skip-scala-version/src/main/scala/GoodCoverage.scala
@@ -1,0 +1,6 @@
+object GoodCoverage {
+
+  def sum(num1: Int, num2: Int) = {
+    num1 + num2
+  }
+}

--- a/src/sbt-test/scoverage/skip-scala-version/src/test/scala/GoodCoverageSpec.scala
+++ b/src/sbt-test/scoverage/skip-scala-version/src/test/scala/GoodCoverageSpec.scala
@@ -1,0 +1,7 @@
+import org.scalatest.{FlatSpec, Matchers}
+
+class GoodCoverageSpec extends FlatSpec with Matchers {
+  "sum two numbers" should "be mathematically corrent sum" in {
+    GoodCoverage.sum(1, 2) shouldBe 3
+  }
+}

--- a/src/sbt-test/scoverage/skip-scala-version/test
+++ b/src/sbt-test/scoverage/skip-scala-version/test
@@ -1,0 +1,11 @@
+# check scalaVersion setting
+> checkScalaVersion "2.10.4"
+> coverage
+> test
+$ exists target/scala-2.10/scoverage-data
+> set scalaVersion := {"2.12.0-M5"}
+> checkScalaVersion "2.12.0-M5"
+> coverage
+> test
+$ exists target/scala-2.10/scoverage-data
+$ absent target/scala-2.12.0-M5/scoverage-data

--- a/src/sbt-test/scoverage/skip/build.sbt
+++ b/src/sbt-test/scoverage/skip/build.sbt
@@ -1,0 +1,42 @@
+/*
+  The projects test aggregation of coverage reports from two sub-projects.
+  The sub-projects are in the directories partA and partB.
+*/
+
+lazy val commonSettings = Seq(
+  organization := "org.scoverage",
+  version := "0.1.0",
+  scalaVersion := "2.10.4"
+)
+
+lazy val specs2Lib = "org.specs2" %% "specs2" % "2.3.13" % "test"
+
+def module(name: String) = {
+  val id = s"part$name"
+  Project(id = id, base = file(id))
+    .settings(commonSettings: _*)
+    .settings(
+      Keys.name := name,
+      libraryDependencies += specs2Lib
+    )
+}
+
+lazy val partA = module("A")
+lazy val partB = module("B").settings(
+  coverageSkip := true
+)
+
+lazy val root = (project in file("."))
+  .settings(commonSettings:_*)
+  .settings(
+    name := "root",
+    test := { }
+  ).aggregate(
+    partA,
+    partB
+  )
+
+resolvers in ThisBuild ++= {
+  if (sys.props.get("plugin.version").map(_.endsWith("-SNAPSHOT")).getOrElse(false)) Seq(Resolver.sonatypeRepo("snapshots"))
+  else Seq.empty
+}

--- a/src/sbt-test/scoverage/skip/partA/src/main/scala/org/scoverage/issue53/part/a/AdderScala.scala
+++ b/src/sbt-test/scoverage/skip/partA/src/main/scala/org/scoverage/issue53/part/a/AdderScala.scala
@@ -1,0 +1,10 @@
+package org.scoverage.issue53.part.a
+
+/**
+ * Created by Mikhail Kokho on 7/10/2015.
+ */
+object AdderScala {
+
+  def add(x: Int, y: Int) = x + y
+
+}

--- a/src/sbt-test/scoverage/skip/partA/src/test/scala/AdderTestSuite.scala
+++ b/src/sbt-test/scoverage/skip/partA/src/test/scala/AdderTestSuite.scala
@@ -1,0 +1,13 @@
+import org.specs2.mutable._
+import org.scoverage.issue53.part.a.AdderScala
+
+/**
+ * Created by Mikhail Kokho on 7/10/2015.
+ */
+class AdderTestSuite extends Specification {
+  "Adder" should {
+    "sum two numbers" in {
+      AdderScala.add(1, 2) mustEqual 3
+    }
+  }
+}

--- a/src/sbt-test/scoverage/skip/partB/src/main/scala/org/scoverage/issue53/part/b/SubtractorScala.scala
+++ b/src/sbt-test/scoverage/skip/partB/src/main/scala/org/scoverage/issue53/part/b/SubtractorScala.scala
@@ -1,0 +1,11 @@
+
+package org.scoverage.issue53.part.b
+
+/**
+ * Created by Mikhail Kokho on 7/10/2015.
+ */
+object SubtractorScala {
+
+  def minus(x: Int, y: Int) = x - y
+
+}

--- a/src/sbt-test/scoverage/skip/partB/src/test/scala/SubtractorTestSuite.scala
+++ b/src/sbt-test/scoverage/skip/partB/src/test/scala/SubtractorTestSuite.scala
@@ -1,0 +1,14 @@
+import org.specs2.mutable._
+import org.scoverage.issue53.part.b.SubtractorScala
+
+/**
+ * Created by Mikhail Kokho on 7/10/2015.
+ */
+class SubtractorTestSuite extends Specification {
+  "Subtractor" should {
+    "subtract two numbers" in {
+      SubtractorScala.minus(2, 1) mustEqual 1
+    }
+  }
+}
+

--- a/src/sbt-test/scoverage/skip/project/plugins.sbt
+++ b/src/sbt-test/scoverage/skip/project/plugins.sbt
@@ -1,0 +1,20 @@
+// The Typesafe repository
+resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+
+//scoverage needs this
+resolvers += Classpaths.sbtPluginReleases
+
+val pluginVersion = sys.props.getOrElse(
+  "plugin.version",
+  throw new RuntimeException(
+    """|The system property 'plugin.version' is not defined.
+       |Specify this property using the scriptedLaunchOpts -D.""".stripMargin))
+
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % pluginVersion)
+
+resolvers ++= {
+  if (pluginVersion.endsWith("-SNAPSHOT"))
+    Seq(Resolver.sonatypeRepo("snapshots"))
+  else
+    Seq.empty
+}

--- a/src/sbt-test/scoverage/skip/test
+++ b/src/sbt-test/scoverage/skip/test
@@ -1,0 +1,14 @@
+# run scoverage using the coverage task
+> clean
+> coverage
+> test
+# There should be scoverage-data directory
+$ exists partA/target/scala-2.10/scoverage-data
+$ absent partB/target/scala-2.10/scoverage-data
+> coverageReport
+# There should be scoverage-report directory
+$ exists partA/target/scala-2.10/scoverage-report
+$ absent partB/target/scala-2.10/scoverage-report
+> coverageAggregate
+# There should be a root scoverage-report directory
+$ exists target/scala-2.10/scoverage-report


### PR DESCRIPTION
Using that flag user can exclude any of the subprojects from coverage generation:
```
lazy val partA = module("A")
lazy val partB = module("B").settings(
   coverageSkip := true
)
```

After that `coverage` task won't change value of `coverageEnabled` of the subproject.

It is also possible to skip project on per scalaVersion basis:
`coverageSkip := scalaVersion.value.startsWith("2.12")`