### PR TITLE
Update preserve-set to use crossScalaVersions

### DIFF
--- a/src/sbt-test/scoverage/preserve-set/build.sbt
+++ b/src/sbt-test/scoverage/preserve-set/build.sbt
@@ -2,7 +2,9 @@ import sbt.complete.DefaultParsers._
 
 version := "0.1"
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.8"
+
+crossScalaVersions := Seq("2.10.6", "2.11.8")
 
 libraryDependencies += "org.specs2" %% "specs2" % "2.3.13" % "test"
 
@@ -13,7 +15,23 @@ checkScalaVersion := {
   ()
 }
 
+val checkScoverageEnabled = inputKey[Unit]("Input task to compare the value of coverageEnabled setting with a given input.")
+checkScoverageEnabled := {
+  val arg: String = (Space ~> StringBasic).parsed
+  if (coverageEnabled.value.toString != arg) error(s"coverageEnabled [${coverageEnabled.value}] not equal to expected [$arg]")
+  ()
+}
+
+
 resolvers ++= {
   if (sys.props.get("plugin.version").map(_.endsWith("-SNAPSHOT")).getOrElse(false)) Seq(Resolver.sonatypeRepo("snapshots"))
   else Seq.empty
+}
+
+// We force coverage to be always disabled for 2.10. This is not an uncommon real world scenario
+coverageEnabled := {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, 10)) => false
+    case _ => coverageEnabled.value
+  }
 }

--- a/src/sbt-test/scoverage/preserve-set/test
+++ b/src/sbt-test/scoverage/preserve-set/test
@@ -1,11 +1,19 @@
 # check scalaVersion setting
-> checkScalaVersion "2.10.4"
-# override scalaVersion setting
-> set scalaVersion := {"2.10.5"}
-> checkScalaVersion "2.10.5"
-# activate coverage - override should still be present
+> checkScalaVersion "2.11.8"
+> checkScoverageEnabled "false"
 > coverage
-> checkScalaVersion "2.10.5"
-# turn off coverage - override should still be present
+> checkScoverageEnabled "true"
 > coverageOff
-> checkScalaVersion "2.10.5"
+> checkScalaVersion "2.11.8"
+> checkScoverageEnabled "false"
+# changs scala version
+> ++2.10.6
+> checkScalaVersion "2.10.6"
+> checkScoverageEnabled "false"
+> coverage
+> checkScalaVersion "2.10.6"
+# We want coverage to be false, as we set it in the build.sbt
+> checkScoverageEnabled "false"
+> coverageOff
+> checkScalaVersion "2.10.6"
+> checkScoverageEnabled "false"


### PR DESCRIPTION
This PR changes preserve-set to use `crossScalaVersions` and checks that coverage is always off for 2.10.

This PR passes tests using https://github.com/scoverage/sbt-scoverage/pull/182, used to fail on master before that PR was merged. 