### PR TITLE
(DO NOT MERGE: POC ONLY) Prevent publishing of instrumented code

### DIFF
--- a/src/main/scala/scoverage/ScoverageKeys.scala
+++ b/src/main/scala/scoverage/ScoverageKeys.scala
@@ -17,5 +17,6 @@ object ScoverageKeys {
   lazy val coverageOutputDebug = settingKey[Boolean]("turn on the debug report")
   lazy val coverageCleanSubprojectFiles = settingKey[Boolean]("removes subproject data after an aggregation")
   lazy val coverageOutputTeamCity = settingKey[Boolean]("turn on teamcity reporting")
+  lazy val coverageAllowInstrumentedPublish = settingKey[Boolean]("Allow publishing of instrumented code")
   lazy val coverageScalacPluginVersion = settingKey[String]("version of scalac-scoverage-plugin to use")
 }

--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -25,6 +25,7 @@ object ScoverageSbtPlugin extends AutoPlugin {
 
   override def globalSettings: Seq[Def.Setting[_]] = super.globalSettings ++ Seq(
     coverageEnabled := false,
+    coverageAllowInstrumentedPublish := false,
     coverageExcludedPackages := "",
     coverageExcludedFiles := "",
     coverageMinimum := 0, // default is no minimum
@@ -47,8 +48,14 @@ object ScoverageSbtPlugin extends AutoPlugin {
   override def projectSettings: Seq[Setting[_]] = Seq(
     ivyConfigurations += ScoveragePluginConfig,
     coverageReport <<= coverageReport0,
-    coverageAggregate <<= coverageAggregate0
+    coverageAggregate <<= coverageAggregate0,
+    (packageBin in Compile) <<= (packageBin in Compile) dependsOn checkAllowInstrumentedPublish
   ) ++ coverageSettings ++ scalacSettings
+
+  private lazy val checkAllowInstrumentedPublish = Def.task {
+    if (coverageAllowInstrumentedPublish.value == false && coverageEnabled.value == true  )
+       throw new Exception(s"""Fatal: Publishing instrumented is not permitted. Please use "coverageAllowInstrumentedPublish"" to override""")
+  }
 
   private lazy val coverageSettings = Seq(
     libraryDependencies  ++= {


### PR DESCRIPTION
Simple POC that prevents publishing if `coverageOn` has been called. Works in simple uses, needs refining if the concept is approved.