### PR TITLE
Remove from README.md info about setting coveragEnabled := true

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,6 @@ or if you have integration tests as well
 $ sbt clean coverage it:test
 ```
 
-To enable coverage directly in your build, use:
-```
-coverageEnabled := true
-```
-
 To generate the coverage reports run
 ```
 $ sbt coverageReport


### PR DESCRIPTION
We shouldn't recommend that in documentation as this is source of many user problems.
