### PR TITLE
Update default Scoverage compiler plugin version

### DIFF
--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -11,7 +11,7 @@ object ScoverageSbtPlugin extends AutoPlugin {
   val ScalacRuntimeArtifact = "scalac-scoverage-runtime"
   val ScalacPluginArtifact = "scalac-scoverage-plugin"
   // this should match the version defined in build.sbt
-  val DefaultScoverageVersion = "1.3.0-SNAPSHOT"
+  val DefaultScoverageVersion = "1.3.0"
   val autoImport = ScoverageKeys
   lazy val ScoveragePluginConfig = config("scoveragePlugin").hide
 


### PR DESCRIPTION
The 1.5.0 release of the plugin isn't yet synced to Maven Central, but I just tried depending on the Sonatype releases version, and it seems that I still have to set the `coverageScalacPluginVersion` or I get the snapshot.

This PR fixes this by updating the default version. /cc @gslowikowski