### PR TITLE
add new coverageExcludedSymbols setting

### DIFF
--- a/src/main/scala/scoverage/ScoverageKeys.scala
+++ b/src/main/scala/scoverage/ScoverageKeys.scala
@@ -8,6 +8,7 @@ object ScoverageKeys {
   lazy val coverageAggregate = taskKey[Unit]("aggregate reports from subprojects")
   lazy val coverageExcludedPackages = settingKey[String]("regex for excluded packages")
   lazy val coverageExcludedFiles = settingKey[String]("regex for excluded file paths")
+  lazy val coverageExcludedSymbols = settingKey[String]("regex for excluded symbols")
   lazy val coverageMinimum = settingKey[Double]("scoverage-minimum-coverage")
   lazy val coverageFailOnMinimum = settingKey[Boolean]("if coverage is less than this value then fail build")
   lazy val coverageHighlighting = settingKey[Boolean]("enables range positioning for highlighting")

--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -27,6 +27,7 @@ object ScoverageSbtPlugin extends AutoPlugin {
     coverageEnabled := false,
     coverageExcludedPackages := "",
     coverageExcludedFiles := "",
+    coverageExcludedSymbols := "",
     coverageMinimum := 0, // default is no minimum
     coverageFailOnMinimum := false,
     coverageHighlighting := true,
@@ -79,6 +80,7 @@ object ScoverageSbtPlugin extends AutoPlugin {
           Some(s"-P:scoverage:dataDir:${crossTarget.value.getAbsolutePath}/scoverage-data"),
           Option(coverageExcludedPackages.value.trim).filter(_.nonEmpty).map(v => s"-P:scoverage:excludedPackages:$v"),
           Option(coverageExcludedFiles.value.trim).filter(_.nonEmpty).map(v => s"-P:scoverage:excludedFiles:$v"),
+          Option(coverageExcludedSymbols.value.trim).filter(_.nonEmpty).map(v => s"-P:scoverage:excludedSymbols:$v"),
           // rangepos is broken in some releases of scala so option to turn it off
           if (coverageHighlighting.value) Some("-Yrangepos") else None
         ).flatten

--- a/src/sbt-test/scoverage/coverage-excludes/build.sbt
+++ b/src/sbt-test/scoverage/coverage-excludes/build.sbt
@@ -1,0 +1,17 @@
+version := "0.1"
+
+scalaVersion := "2.10.4"
+
+libraryDependencies += "org.specs2" %% "specs2" % "2.3.13" % "test"
+
+coverageMinimum := 90
+
+coverageFailOnMinimum := true
+
+coverageExcludedPackages := "exclude.*"
+coverageExcludedSymbols := "scala\\.Unit"
+
+resolvers ++= {
+  if (sys.props.get("plugin.version").map(_.endsWith("-SNAPSHOT")).getOrElse(false)) Seq(Resolver.sonatypeRepo("snapshots"))
+  else Seq.empty
+}

--- a/src/sbt-test/scoverage/coverage-excludes/project/plugins.sbt
+++ b/src/sbt-test/scoverage/coverage-excludes/project/plugins.sbt
@@ -1,0 +1,14 @@
+val pluginVersion = sys.props.getOrElse(
+  "plugin.version",
+  throw new RuntimeException(
+    """|The system property 'plugin.version' is not defined.
+       |Specify this property using the scriptedLaunchOpts -D.""".stripMargin))
+
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % pluginVersion)
+
+resolvers ++= {
+  if (pluginVersion.endsWith("-SNAPSHOT"))
+    Seq(Resolver.sonatypeRepo("snapshots"))
+  else
+    Seq.empty
+}

--- a/src/sbt-test/scoverage/coverage-excludes/src/main/scala/NotExcluded.scala
+++ b/src/sbt-test/scoverage/coverage-excludes/src/main/scala/NotExcluded.scala
@@ -1,0 +1,7 @@
+class NotExcluded {
+  def f(): Int = {
+    val a = 1 + 2 + 3
+    val b = 4 + 5
+    a + b
+  }
+}

--- a/src/sbt-test/scoverage/coverage-excludes/src/main/scala/SymbolExcluded.scala
+++ b/src/sbt-test/scoverage/coverage-excludes/src/main/scala/SymbolExcluded.scala
@@ -1,0 +1,6 @@
+package empty
+object SymbolExcluded {
+  def emptyBody(): Unit = {
+    println("this should be excluded from coverage")
+  }
+}

--- a/src/sbt-test/scoverage/coverage-excludes/src/main/scala/exclude/package.scala
+++ b/src/sbt-test/scoverage/coverage-excludes/src/main/scala/exclude/package.scala
@@ -1,0 +1,3 @@
+package object exclude {
+  val i = 5 + 2
+}

--- a/src/sbt-test/scoverage/coverage-excludes/src/test/scala/NotExcludedSpec.scala
+++ b/src/sbt-test/scoverage/coverage-excludes/src/test/scala/NotExcludedSpec.scala
@@ -1,0 +1,10 @@
+import org.specs2.mutable._
+
+class NotExcludedSpec extends Specification {
+
+  "NotExcluded" should {
+    "sum two numbers" in {
+      new NotExcluded().f() mustEqual 15
+    }
+  }
+}

--- a/src/sbt-test/scoverage/coverage-excludes/test
+++ b/src/sbt-test/scoverage/coverage-excludes/test
@@ -1,0 +1,6 @@
+# run scoverage
+> clean
+> coverage
+> test
+# should fail with the the minimum coverage if the exclude does not work
+> coverageReport


### PR DESCRIPTION
Add the `excludedSymbols` parameter introduced in scoverage 1.3.0 

Signed-off-by: Zsigmond Adam Oliver <adam.zsigmond@balabit.com>