### PR TITLE
Some small scripted tests improvements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ publishArtifact in Test := false
 ScriptedPlugin.scriptedSettings
 
 scriptedLaunchOpts ++= Seq(
-  "-Xmx1024M", "-XX:MaxPermSize=256M",
+  "-Xmx1024M",
   "-Dplugin.version=" + version.value
 )
 

--- a/src/sbt-test/scoverage/aggregate/project/plugins.sbt
+++ b/src/sbt-test/scoverage/aggregate/project/plugins.sbt
@@ -4,7 +4,7 @@ val pluginVersion = sys.props.getOrElse(
     """|The system property 'plugin.version' is not defined.
        |Specify this property using the scriptedLaunchOpts -D.""".stripMargin))
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % pluginVersion)
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % pluginVersion)
 
 resolvers ++= {
   if (pluginVersion.endsWith("-SNAPSHOT"))

--- a/src/sbt-test/scoverage/bad-coverage/project/plugins.sbt
+++ b/src/sbt-test/scoverage/bad-coverage/project/plugins.sbt
@@ -4,7 +4,7 @@ val pluginVersion = sys.props.getOrElse(
     """|The system property 'plugin.version' is not defined.
        |Specify this property using the scriptedLaunchOpts -D.""".stripMargin))
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % pluginVersion)
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % pluginVersion)
 
 resolvers ++= {
   if (pluginVersion.endsWith("-SNAPSHOT"))

--- a/src/sbt-test/scoverage/coverage-off/project/plugins.sbt
+++ b/src/sbt-test/scoverage/coverage-off/project/plugins.sbt
@@ -4,7 +4,7 @@ val pluginVersion = sys.props.getOrElse(
     """|The system property 'plugin.version' is not defined.
        |Specify this property using the scriptedLaunchOpts -D.""".stripMargin))
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % pluginVersion)
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % pluginVersion)
 
 resolvers ++= {
   if (pluginVersion.endsWith("-SNAPSHOT"))

--- a/src/sbt-test/scoverage/good-coverage/project/plugins.sbt
+++ b/src/sbt-test/scoverage/good-coverage/project/plugins.sbt
@@ -4,7 +4,7 @@ val pluginVersion = sys.props.getOrElse(
     """|The system property 'plugin.version' is not defined.
        |Specify this property using the scriptedLaunchOpts -D.""".stripMargin))
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % pluginVersion)
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % pluginVersion)
 
 resolvers ++= {
   if (pluginVersion.endsWith("-SNAPSHOT"))

--- a/src/sbt-test/scoverage/preserve-set/project/plugins.sbt
+++ b/src/sbt-test/scoverage/preserve-set/project/plugins.sbt
@@ -4,7 +4,7 @@ val pluginVersion = sys.props.getOrElse(
     """|The system property 'plugin.version' is not defined.
        |Specify this property using the scriptedLaunchOpts -D.""".stripMargin))
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % pluginVersion)
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % pluginVersion)
 
 resolvers ++= {
   if (pluginVersion.endsWith("-SNAPSHOT"))

--- a/src/sbt-test/scoverage/scalac-plugin-version/project/plugins.sbt
+++ b/src/sbt-test/scoverage/scalac-plugin-version/project/plugins.sbt
@@ -4,7 +4,7 @@ val pluginVersion = sys.props.getOrElse(
     """|The system property 'plugin.version' is not defined.
        |Specify this property using the scriptedLaunchOpts -D.""".stripMargin))
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % pluginVersion)
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % pluginVersion)
 
 resolvers ++= {
   if (pluginVersion.endsWith("-SNAPSHOT"))

--- a/src/sbt-test/scoverage/scalajs/project/plugins.sbt
+++ b/src/sbt-test/scoverage/scalajs/project/plugins.sbt
@@ -4,7 +4,7 @@ val pluginVersion = sys.props.getOrElse(
     """|The system property 'plugin.version' is not defined.
        |Specify this property using the scriptedLaunchOpts -D.""".stripMargin))
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % pluginVersion)
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % pluginVersion)
 
 resolvers ++= {
   if (pluginVersion.endsWith("-SNAPSHOT"))


### PR DESCRIPTION
Changes:
- removed `-XX:MaxPermSize` from `scriptedLaunchOpts` (not used in Java 1.8)
- replaced `%%` with `%` in `plugins.sbt` files in all test projects