### PR TITLE
Upgrade `scalac-scoverage-plugin` dependency version to `1.3.1`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ resolvers ++= {
   if (isSnapshot.value) Seq(Resolver.sonatypeRepo("snapshots")) else Nil
 }
 
-libraryDependencies += "org.scoverage" %% "scalac-scoverage-plugin" % "1.3.1-SNAPSHOT"
+libraryDependencies += "org.scoverage" %% "scalac-scoverage-plugin" % "1.3.1"
 
 publishMavenStyle := true
 

--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -11,7 +11,7 @@ object ScoverageSbtPlugin extends AutoPlugin {
   val ScalacRuntimeArtifact = "scalac-scoverage-runtime"
   val ScalacPluginArtifact = "scalac-scoverage-plugin"
   // this should match the version defined in build.sbt
-  val DefaultScoverageVersion = "1.3.1-SNAPSHOT"
+  val DefaultScoverageVersion = "1.3.1"
   val autoImport = ScoverageKeys
   lazy val ScoveragePluginConfig = config("scoveragePlugin").hide
 


### PR DESCRIPTION
`1.3.1` version was published.