### PR TITLE
Cross-SBT release process

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,20 @@ scriptedLaunchOpts ++= Seq(
   "-Dplugin.version=" + version.value
 )
 
-releasePublishArtifactsAction := PgpKeys.publishSigned.value
+import ReleaseTransformations._
+releaseProcess := Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  releaseStepCommandAndRemaining("^ test"),
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+  releaseStepCommandAndRemaining("^ publishSigned"),
+  setNextVersion,
+  commitNextVersion,
+  pushChanges
+)
 
 releaseCrossBuild := false
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,4 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.4")


### PR DESCRIPTION
Changes:
- `build.sbt` modified based on https://github.com/sbt/sbt-release/blob/v1.0.6/build.sbt#L39-L55
- `sbt-release` plugin version upgraded to `1.0.4`
