### PR TITLE
Upgrade SBT version from 0.13.16 to 1.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: scala
 
-script: sbt ++$TRAVIS_SCALA_VERSION ^^$TRAVIS_SBT_VERSION scripted
+script: sbt ^^$TRAVIS_SBT_VERSION scripted
 
 matrix:
   include:
-    - scala: 2.10.6
-      env: TRAVIS_SBT_VERSION="0.13.16"
-    - scala: 2.12.3
-      env: TRAVIS_SBT_VERSION="1.0.0"
+    - env: TRAVIS_SBT_VERSION="0.13.16"
+    - env: TRAVIS_SBT_VERSION="1.0.2"
 
 before_cache:
   - find $HOME/.sbt -name "*.lock" | xargs rm

--- a/build.sbt
+++ b/build.sbt
@@ -16,8 +16,6 @@ publishMavenStyle := true
 
 publishArtifact in Test := false
 
-ScriptedPlugin.scriptedSettings
-
 scriptedLaunchOpts ++= Seq(
   "-Xmx1024M",
   "-Dplugin.version=" + version.value
@@ -69,4 +67,4 @@ pomExtra := {
     </developers>
 }
 
-crossSbtVersions := Vector("0.13.16", "1.0.0")
+crossSbtVersions := Vector("0.13.16", "1.0.2")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.0.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.1")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.4")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")


### PR DESCRIPTION
Changes:

- upgrade SBT version from 0.13.16 to 1.0.2,

- upgrade plugin versions to SBT 1.0.x compatible ones:
  - upgrade PGP plugin version from 1.0.1 to 1.1.0,
  - upgrade Scalariform plugin version from 1.3.0 to 1.8.1,
  - upgrade Release plugin version from 1.0.4 to 1.0.6

- simplify Travis build (don't force Scala versions for SBT versions).