### PR TITLE
Aggregate raw coverage data instead of scoverage XML reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ turn it back off when you're done running reports, use the `coverageOff` command
 
 Sample project with scoverage in both sbt and maven - [the scoverage samples project](https://github.com/scoverage/sbt-scoverage-samples).
 
+## Notes on upgrading to version 1.6.0
+
+* `coverageAggregate` aggregates raw coverage data, not coverage xml reports for modules.
+There is no requirement to generate individual coverage reports for modules (`coverageReport`)
+before generating aggregated report (`coverageAggregate`).
+
+If only aggregated report is required, not executing `coverageReport` can reduce the build time significantly.
+
 ## Notes on upgrading to version 1.3.0
 
 * The object containing the keys has changed from nested to top level so you might need to adjust the import. It's also an auto plugin now, so you might not need the import at all.

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ resolvers ++= {
   if (isSnapshot.value) Seq(Resolver.sonatypeRepo("snapshots")) else Nil
 }
 
-libraryDependencies += "org.scoverage" %% "scalac-scoverage-plugin" % "1.4.0-M5"
+libraryDependencies += "org.scoverage" %% "scalac-scoverage-plugin" % "1.4.0-SNAPSHOT"
 
 publishMavenStyle := true
 

--- a/src/main/scala/scoverage/ScoverageKeys.scala
+++ b/src/main/scala/scoverage/ScoverageKeys.scala
@@ -15,6 +15,7 @@ object ScoverageKeys {
   lazy val coverageOutputXML = settingKey[Boolean]("enables xml report generation")
   lazy val coverageOutputHTML = settingKey[Boolean]("enables html report generation")
   lazy val coverageOutputDebug = settingKey[Boolean]("turn on the debug report")
+  @deprecated("", "1.6.0")
   lazy val coverageCleanSubprojectFiles = settingKey[Boolean]("removes subproject data after an aggregation")
   lazy val coverageOutputTeamCity = settingKey[Boolean]("turn on teamcity reporting")
   lazy val coverageScalacPluginVersion = settingKey[String]("version of scalac-scoverage-plugin to use")

--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -3,7 +3,7 @@ package scoverage
 import sbt.Keys._
 import sbt._
 import sbt.plugins.JvmPlugin
-import scoverage.report.{CoverageAggregator, CoberturaXmlWriter, ScoverageHtmlWriter, ScoverageXmlWriter}
+import scoverage.report.{CoberturaXmlWriter, CoverageAggregator, ScoverageHtmlWriter, ScoverageXmlWriter}
 
 object ScoverageSbtPlugin extends AutoPlugin {
 
@@ -11,7 +11,7 @@ object ScoverageSbtPlugin extends AutoPlugin {
   val ScalacRuntimeArtifact = "scalac-scoverage-runtime"
   val ScalacPluginArtifact = "scalac-scoverage-plugin"
   // this should match the version defined in build.sbt
-  val DefaultScoverageVersion = "1.4.0-M5"
+  val DefaultScoverageVersion = "1.4.0-SNAPSHOT"
   val autoImport = ScoverageKeys
   lazy val ScoveragePluginConfig = config("scoveragePlugin").hide
 
@@ -132,9 +132,8 @@ object ScoverageSbtPlugin extends AutoPlugin {
     val log = streams.value.log
     log.info(s"Aggregating coverage from subprojects...")
 
-    val xmlReportFiles = crossTarget.all(aggregateFilter).value map (_ / "scoverage-report" / Constants
-      .XMLReportFilename) filter (_.isFile())
-    CoverageAggregator.aggregate(xmlReportFiles, coverageCleanSubprojectFiles.value) match {
+    val dataDirs = crossTarget.all(aggregateFilter).value map (_ / Constants.DataDir) filter (_.isDirectory)
+    CoverageAggregator.aggregate(dataDirs) match {
       case Some(cov) =>
         writeReports(
           crossTarget.value,

--- a/src/sbt-test/scoverage/aggregate-only/build.sbt
+++ b/src/sbt-test/scoverage/aggregate-only/build.sbt
@@ -1,0 +1,40 @@
+/*
+  The projects test aggregation of coverage reports from two sub-projects.
+  The sub-projects are in the directories partA and partB.
+*/
+
+lazy val commonSettings = Seq(
+  organization := "org.scoverage",
+  version := "0.1.0",
+  scalaVersion := "2.10.4"
+)
+
+lazy val specs2Lib = "org.specs2" %% "specs2" % "2.3.13" % "test"
+
+def module(name: String) = {
+  val id = s"part$name"
+  Project(id = id, base = file(id))
+    .settings(commonSettings: _*)
+    .settings(
+      Keys.name := name,
+      libraryDependencies += specs2Lib
+    )
+}
+
+lazy val partA = module("A")
+lazy val partB = module("B")
+
+lazy val root = (project in file("."))
+  .settings(commonSettings:_*)
+  .settings(
+    name := "root",
+    test := { }
+  ).aggregate(
+    partA,
+    partB
+  )
+
+resolvers in ThisBuild ++= {
+  if (sys.props.get("plugin.version").map(_.endsWith("-SNAPSHOT")).getOrElse(false)) Seq(Resolver.sonatypeRepo("snapshots"))
+  else Seq.empty
+}

--- a/src/sbt-test/scoverage/aggregate-only/partA/src/main/scala/org/scoverage/issue53/part/a/AdderScala.scala
+++ b/src/sbt-test/scoverage/aggregate-only/partA/src/main/scala/org/scoverage/issue53/part/a/AdderScala.scala
@@ -1,0 +1,10 @@
+package org.scoverage.issue53.part.a
+
+/**
+ * Created by Mikhail Kokho on 7/10/2015.
+ */
+object AdderScala {
+
+  def add(x: Int, y: Int) = x + y
+
+}

--- a/src/sbt-test/scoverage/aggregate-only/partA/src/test/scala/AdderTestSuite.scala
+++ b/src/sbt-test/scoverage/aggregate-only/partA/src/test/scala/AdderTestSuite.scala
@@ -1,0 +1,13 @@
+import org.specs2.mutable._
+import org.scoverage.issue53.part.a.AdderScala
+
+/**
+ * Created by Mikhail Kokho on 7/10/2015.
+ */
+class AdderTestSuite extends Specification {
+  "Adder" should {
+    "sum two numbers" in {
+      AdderScala.add(1, 2) mustEqual 3
+    }
+  }
+}

--- a/src/sbt-test/scoverage/aggregate-only/partB/src/main/scala/org/scoverage/issue53/part/b/SubtractorScala.scala
+++ b/src/sbt-test/scoverage/aggregate-only/partB/src/main/scala/org/scoverage/issue53/part/b/SubtractorScala.scala
@@ -1,0 +1,11 @@
+
+package org.scoverage.issue53.part.b
+
+/**
+ * Created by Mikhail Kokho on 7/10/2015.
+ */
+object SubtractorScala {
+
+  def minus(x: Int, y: Int) = x - y
+
+}

--- a/src/sbt-test/scoverage/aggregate-only/partB/src/test/scala/SubtractorTestSuite.scala
+++ b/src/sbt-test/scoverage/aggregate-only/partB/src/test/scala/SubtractorTestSuite.scala
@@ -1,0 +1,14 @@
+import org.specs2.mutable._
+import org.scoverage.issue53.part.b.SubtractorScala
+
+/**
+ * Created by Mikhail Kokho on 7/10/2015.
+ */
+class SubtractorTestSuite extends Specification {
+  "Subtractor" should {
+    "subtract two numbers" in {
+      SubtractorScala.minus(2, 1) mustEqual 1
+    }
+  }
+}
+

--- a/src/sbt-test/scoverage/aggregate-only/project/plugins.sbt
+++ b/src/sbt-test/scoverage/aggregate-only/project/plugins.sbt
@@ -1,0 +1,14 @@
+val pluginVersion = sys.props.getOrElse(
+  "plugin.version",
+  throw new RuntimeException(
+    """|The system property 'plugin.version' is not defined.
+       |Specify this property using the scriptedLaunchOpts -D.""".stripMargin))
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % pluginVersion)
+
+resolvers ++= {
+  if (pluginVersion.endsWith("-SNAPSHOT"))
+    Seq(Resolver.sonatypeRepo("snapshots"))
+  else
+    Seq.empty
+}

--- a/src/sbt-test/scoverage/aggregate-only/test
+++ b/src/sbt-test/scoverage/aggregate-only/test
@@ -1,0 +1,14 @@
+# run scoverage using the coverage task
+> clean
+> coverage
+> test
+# There should be scoverage-data directories for modules
+$ exists partA/target/scala-2.10/scoverage-data
+$ exists partB/target/scala-2.10/scoverage-data
+# Generate aggregated reports without generating per-module reports first
+> coverageAggregate
+# There shouldn't be scoverage-report directories for modules
+-$ exists partA/target/scala-2.10/scoverage-report
+-$ exists partB/target/scala-2.10/scoverage-report
+# There should be a root scoverage-report directory
+$ exists target/scala-2.10/scoverage-report


### PR DESCRIPTION
This change is closely related to scoverage/scalac-scoverage-plugin#241

There is no requirement to generate individual coverage reports for modules (`coverageReport`)
before generating aggregated report (`coverageAggregate`) anymore.