### PR TITLE
Report test names

### DIFF
--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -101,6 +101,7 @@ object ScoverageSbtPlugin extends AutoPlugin {
           Option(coverageExcludedFiles.value.trim)
             .filter(_.nonEmpty)
             .map(v => s"-P:scoverage:excludedFiles:$v"),
+          Some("-P:scoverage:reportTestName"),
           // rangepos is broken in some releases of scala so option to turn it off
           if (coverageHighlighting.value) Some("-Yrangepos") else None
         ).flatten


### PR DESCRIPTION
This PR accompanies https://github.com/scoverage/scalac-scoverage-plugin/pull/282

After the PR on the compiler plugin has been merged, the dependency versions need to be changed for the feature to work.