### PR TITLE
Fix Scala 2.13.1 integration

### DIFF
--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -11,7 +11,7 @@ object ScoverageSbtPlugin extends AutoPlugin {
   val ScalacRuntimeArtifact = "scalac-scoverage-runtime"
   val ScalacPluginArtifact = "scalac-scoverage-plugin"
   // this should match the version defined in build.sbt
-  val DefaultScoverageVersion = "1.4.0"
+  val DefaultScoverageVersion = "1.4.1-SNAPSHOT"
   val autoImport = ScoverageKeys
   lazy val ScoveragePluginConfig = config("scoveragePlugin").hide
 


### PR DESCRIPTION
This fixes #295 by defaulting to a version of scalac-scoverage-plugin that is compatible with every scala version known to man except for 2.13.0.

It cannot be merged in its current state, as it depends on a SNAPSHOT version of scalac-scoverage-plugin. This is more of a convenience for maintainers, who can just checkout this PR and the [scalac-scoverage-plugin](https://github.com/scoverage/scalac-scoverage-plugin/pull/283) one, publish both locally, and confirm that it works as expected on 2.13.1.