### PR TITLE
Update Default Scoverage Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ sbt.version = 1.1.1
 
 Add the plugin in project/plugins.sbt:
 ```scala
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 ```
 
 Run the tests with enabled coverage:

--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -11,7 +11,7 @@ object ScoverageSbtPlugin extends AutoPlugin {
   val ScalacRuntimeArtifact = "scalac-scoverage-runtime"
   val ScalacPluginArtifact = "scalac-scoverage-plugin"
   // this should match the version defined in build.sbt
-  val DefaultScoverageVersion = "1.4.0"
+  val DefaultScoverageVersion = "1.4.1"
   val autoImport = ScoverageKeys
   lazy val ScoveragePluginConfig = config("scoveragePlugin").hide
 


### PR DESCRIPTION
Add support for Scala 2.13.1

This fixes #295 by defaulting to a version of scalac-scoverage-plugin that is compatible with every scala version known to man except for 2.13.0.