### PR TITLE
Bump scalac-scoverage-plugin version

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,15 +14,7 @@ jobs:
       matrix:
         java: [ '11' ]
         scala: [
-            { version: '2.12.13' },
-            { version: '2.12.12' },
-            { version: '2.12.11' },
-            { version: '2.12.10' },
-            { version: '2.13.4' },
-            { version: '2.13.3' },
-            { version: '2.13.2' },
-            { version: '2.13.1' },
-            { version: '2.13.0' }
+            { version: '2.12.13' }
           ]
     steps:
       - name: checkout the repo

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ resolvers ++= {
   if (isSnapshot.value) Seq(Resolver.sonatypeRepo("snapshots")) else Nil
 }
 
-libraryDependencies += "org.scoverage" %% "scalac-scoverage-plugin" % "1.4.0"
+libraryDependencies += "org.scoverage" %% "scalac-scoverage-plugin" % "1.4.2"
 
 publishMavenStyle := true
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,11 +10,12 @@ resolvers ++= {
   if (isSnapshot.value) Seq(Resolver.sonatypeRepo("snapshots")) else Nil
 }
 
-libraryDependencies += "org.scoverage" %% "scalac-scoverage-plugin" % "1.4.2"
+libraryDependencies +=
+  "org.scoverage" %% "scalac-scoverage-plugin" % "1.4.3-SNAPSHOT" cross CrossVersion.full
 
 publishMavenStyle := true
 
-publishArtifact in Test := false
+Test / publishArtifact := false
 
 scriptedLaunchOpts ++= Seq(
   "-Xmx1024M",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.5.1

--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -11,7 +11,7 @@ object ScoverageSbtPlugin extends AutoPlugin {
   val ScalacRuntimeArtifact = "scalac-scoverage-runtime"
   val ScalacPluginArtifact = "scalac-scoverage-plugin"
   // this should match the version defined in build.sbt
-  val DefaultScoverageVersion = "1.4.1"
+  val DefaultScoverageVersion = "1.4.2"
   val autoImport = ScoverageKeys
   lazy val ScoveragePluginConfig = config("scoveragePlugin").hide
 

--- a/src/sbt-test/scoverage/aggregate-only/build.sbt
+++ b/src/sbt-test/scoverage/aggregate-only/build.sbt
@@ -6,7 +6,7 @@
 lazy val commonSettings = Seq(
   organization := "org.scoverage",
   version := "0.1.0",
-  scalaVersion := "2.12.8"
+  scalaVersion := "2.12.13"
 )
 
 lazy val specs2Lib = "org.specs2" %% "specs2" % "2.5" % "test"

--- a/src/sbt-test/scoverage/aggregate/build.sbt
+++ b/src/sbt-test/scoverage/aggregate/build.sbt
@@ -6,7 +6,7 @@
 lazy val commonSettings = Seq(
   organization := "org.scoverage",
   version := "0.1.0",
-  scalaVersion := "2.12.8"
+  scalaVersion := "2.12.13"
 )
 
 lazy val specs2Lib = "org.specs2" %% "specs2" % "2.5" % "test"

--- a/src/sbt-test/scoverage/bad-coverage/build.sbt
+++ b/src/sbt-test/scoverage/bad-coverage/build.sbt
@@ -1,6 +1,6 @@
 version := "0.1"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.12.13"
 
 libraryDependencies += "org.specs2" %% "specs2" % "2.5" % "test"
 

--- a/src/sbt-test/scoverage/coverage-off/build.sbt
+++ b/src/sbt-test/scoverage/coverage-off/build.sbt
@@ -1,6 +1,6 @@
 version := "0.1"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.12.13"
 
 libraryDependencies += "org.specs2" %% "specs2" % "2.5" % "test"
 

--- a/src/sbt-test/scoverage/good-coverage/build.sbt
+++ b/src/sbt-test/scoverage/good-coverage/build.sbt
@@ -1,6 +1,6 @@
 version := "0.1"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.12.13"
 
 libraryDependencies += "org.specs2" %% "specs2" % "2.5" % "test"
 

--- a/src/sbt-test/scoverage/preserve-set/build.sbt
+++ b/src/sbt-test/scoverage/preserve-set/build.sbt
@@ -2,9 +2,9 @@ import sbt.complete.DefaultParsers._
 
 version := "0.1"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.12.13"
 
-crossScalaVersions := Seq("2.10.6", "2.12.8")
+crossScalaVersions := Seq("2.10.6", "2.12.13")
 
 libraryDependencies += "org.specs2" %% "specs2" % "2.5" % "test"
 

--- a/src/sbt-test/scoverage/preserve-set/test
+++ b/src/sbt-test/scoverage/preserve-set/test
@@ -1,10 +1,10 @@
 # check scalaVersion setting
-> checkScalaVersion "2.12.8"
+> checkScalaVersion "2.12.13"
 > checkScoverageEnabled "false"
 > coverage
 > checkScoverageEnabled "true"
 > coverageOff
-> checkScalaVersion "2.12.8"
+> checkScalaVersion "2.12.13"
 > checkScoverageEnabled "false"
 # changs scala version
 > ++2.10.6

--- a/src/sbt-test/scoverage/scalajs/build.sbt
+++ b/src/sbt-test/scoverage/scalajs/build.sbt
@@ -4,11 +4,10 @@ import sbtcrossproject.CrossType
 lazy val root = (project in file(".")).aggregate(crossJS, crossJVM)
 
 lazy val cross = CrossProject("sjstest", file("sjstest"))(JVMPlatform, JSPlatform)
-  .crossType(CrossType.Full)
   .settings(
-    scalaVersion := "2.12.8",
+    scalaVersion := "2.13.5",
     libraryDependencies ++= Seq(
-      "org.scalatest" %%% "scalatest" % "3.0.0" % "test"
+      "org.scalatest" %%% "scalatest" % "3.2.8" % "test"
     )
   )
 

--- a/src/sbt-test/scoverage/scalajs/project/plugins.sbt
+++ b/src/sbt-test/scoverage/scalajs/project/plugins.sbt
@@ -13,6 +13,6 @@ resolvers ++= {
     Seq.empty
 }
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.27")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.1")
 
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")

--- a/src/sbt-test/scoverage/scalajs/sjstest/js/src/test/scala/JsTest.scala
+++ b/src/sbt-test/scoverage/scalajs/sjstest/js/src/test/scala/JsTest.scala
@@ -1,6 +1,7 @@
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class JsTest extends FlatSpec with Matchers {
+class JsTest extends AnyFlatSpec with Matchers {
 
   "JS UnderTest" should "work on JS" in {
     UnderTest.jsMethod shouldBe "js"

--- a/src/sbt-test/scoverage/scalajs/sjstest/jvm/src/test/scala/JvmTest.scala
+++ b/src/sbt-test/scoverage/scalajs/sjstest/jvm/src/test/scala/JvmTest.scala
@@ -1,6 +1,7 @@
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class JvmTest extends FlatSpec with Matchers {
+class JvmTest extends AnyFlatSpec with Matchers {
 
   "JVM UnderTest" should "work on JVM" in {
     UnderTest.jvmMethod shouldBe "jvm"

--- a/src/sbt-test/scoverage/scalajs/sjstest/shared/src/test/scala/SharedTest.scala
+++ b/src/sbt-test/scoverage/scalajs/sjstest/shared/src/test/scala/SharedTest.scala
@@ -1,6 +1,7 @@
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class SharedTest extends FlatSpec with Matchers {
+class SharedTest extends AnyFlatSpec with Matchers {
 
   "Shared UnderTest" should "return where it works" in {
     UnderTest.onJsAndJvm shouldBe "js and jvm"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.6.2-SNAPSHOT"
+(ThisBuild / version) := "1.6.2-SNAPSHOT"


### PR DESCRIPTION
~If I released everything correctly this should address #321 after a release.~

Work related to https://github.com/scoverage/scalac-scoverage-plugin/pull/311. There still seems to be some failing issue in js land.