### PR TITLE
Remove cross from release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
   runClean,
-  releaseStepCommandAndRemaining("^ test"),
+  releaseStepCommandAndRemaining("test"),
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,


### PR DESCRIPTION
We no longer cross publishing for sbt, and therefore don't need to do the cross test