### PR TITLE
Make sure buildInfo is in it's own package.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,7 @@ lazy val root = Project("sbt-scoverage", file("."))
       "org.scoverage" %% "scalac-scoverage-plugin" % scoverageVersion cross (CrossVersion.full),
     ),
     buildInfoKeys := Seq[BuildInfoKey]("scoverageVersion" -> scoverageVersion),
+    buildInfoPackage := "scoverage",
     Test / fork := false,
     Test / publishArtifact := false,
     Test / parallelExecution := false,

--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -5,7 +5,6 @@ import sbt._
 import sbt.plugins.JvmPlugin
 import scoverage.report.{CoberturaXmlWriter, CoverageAggregator, ScoverageHtmlWriter, ScoverageXmlWriter}
 import java.time.Instant
-import buildinfo.BuildInfo
 
 object ScoverageSbtPlugin extends AutoPlugin {
 


### PR DESCRIPTION
If not, this could cause issues downstream if there are multiple
plugins or applications that aren't namespacing their buildInfo
packages. I actually just hit on this and realized I forgot to
add in buildInfoPackage here.