### PR TITLE
Remove scala-compiler as a dep.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,6 @@ lazy val root = Project("sbt-scoverage", file("."))
   .enablePlugins(SbtPlugin, BuildInfoPlugin)
   .settings(
     libraryDependencies ++= Seq(
-      "org.scala-lang" % "scala-compiler" % scalaVersion.value % Compile,
       "org.scoverage" %% "scalac-scoverage-plugin" % scoverageVersion cross (CrossVersion.full)
     ),
     buildInfoKeys := Seq[BuildInfoKey]("scoverageVersion" -> scoverageVersion),


### PR DESCRIPTION
I didn't catch this before, but I'm unsure why this was added in this
commit:
https://github.com/scoverage/sbt-scoverage/commit/5d298ed9fc032025f2023bf31fe869c0b7361001,
but it shouldn't be needed.