### PR TITLE
Update tests in scripted.

### DIFF
--- a/src/sbt-test/scoverage/aggregate-only/build.sbt
+++ b/src/sbt-test/scoverage/aggregate-only/build.sbt
@@ -1,15 +1,13 @@
 /*
   The projects test aggregation of coverage reports from two sub-projects.
   The sub-projects are in the directories partA and partB.
-*/
+ */
 
 lazy val commonSettings = Seq(
   organization := "org.scoverage",
   version := "0.1.0",
-  scalaVersion := "2.12.13"
+  scalaVersion := "2.13.5"
 )
-
-lazy val specs2Lib = "org.specs2" %% "specs2" % "2.5" % "test"
 
 def module(name: String) = {
   val id = s"part$name"
@@ -17,7 +15,7 @@ def module(name: String) = {
     .settings(commonSettings: _*)
     .settings(
       Keys.name := name,
-      libraryDependencies += specs2Lib
+      libraryDependencies += "org.scalameta" %% "munit" % "0.7.25" % Test
     )
 }
 
@@ -25,16 +23,18 @@ lazy val partA = module("A")
 lazy val partB = module("B")
 
 lazy val root = (project in file("."))
-  .settings(commonSettings:_*)
+  .settings(commonSettings: _*)
   .settings(
     name := "root",
-    test := { }
-  ).aggregate(
+    test := {}
+  )
+  .aggregate(
     partA,
     partB
   )
 
 ThisBuild / resolvers ++= {
-  if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT"))) Seq(Resolver.sonatypeRepo("snapshots"))
+  if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
+    Seq(Resolver.sonatypeRepo("snapshots"))
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/aggregate-only/partA/src/test/scala/AdderTestSuite.scala
+++ b/src/sbt-test/scoverage/aggregate-only/partA/src/test/scala/AdderTestSuite.scala
@@ -1,13 +1,10 @@
-import org.specs2.mutable._
+import munit.FunSuite
 import org.scoverage.issue53.part.a.AdderScala
 
-/**
- * Created by Mikhail Kokho on 7/10/2015.
- */
-class AdderTestSuite extends Specification {
-  "Adder" should {
-    "sum two numbers" in {
-      AdderScala.add(1, 2) mustEqual 3
-    }
+/** Created by Mikhail Kokho on 7/10/2015.
+  */
+class AdderTestSuite extends FunSuite {
+  test("Adder should sum two numbers") {
+    assertEquals(AdderScala.add(1, 2), 3)
   }
 }

--- a/src/sbt-test/scoverage/aggregate-only/partB/src/test/scala/SubtractorTestSuite.scala
+++ b/src/sbt-test/scoverage/aggregate-only/partB/src/test/scala/SubtractorTestSuite.scala
@@ -1,14 +1,10 @@
-import org.specs2.mutable._
+import munit.FunSuite
 import org.scoverage.issue53.part.b.SubtractorScala
 
-/**
- * Created by Mikhail Kokho on 7/10/2015.
- */
-class SubtractorTestSuite extends Specification {
-  "Subtractor" should {
-    "subtract two numbers" in {
-      SubtractorScala.minus(2, 1) mustEqual 1
-    }
+/** Created by Mikhail Kokho on 7/10/2015.
+  */
+class SubtractorTestSuite extends FunSuite {
+  test("Subtractor should subtract two numbers") {
+    assertEquals(SubtractorScala.minus(2, 1), 1)
   }
 }
-

--- a/src/sbt-test/scoverage/aggregate-only/test
+++ b/src/sbt-test/scoverage/aggregate-only/test
@@ -3,12 +3,12 @@
 > coverage
 > test
 # There should be scoverage-data directories for modules
-$ exists partA/target/scala-2.12/scoverage-data
-$ exists partB/target/scala-2.12/scoverage-data
+$ exists partA/target/scala-2.13/scoverage-data
+$ exists partB/target/scala-2.13/scoverage-data
 # Generate aggregated reports without generating per-module reports first
 > coverageAggregate
 # There shouldn't be scoverage-report directories for modules
--$ exists partA/target/scala-2.12/scoverage-report
--$ exists partB/target/scala-2.12/scoverage-report
+-$ exists partA/target/scala-2.13/scoverage-report
+-$ exists partB/target/scala-2.13/scoverage-report
 # There should be a root scoverage-report directory
-$ exists target/scala-2.12/scoverage-report
+$ exists target/scala-2.13/scoverage-report

--- a/src/sbt-test/scoverage/aggregate/build.sbt
+++ b/src/sbt-test/scoverage/aggregate/build.sbt
@@ -1,15 +1,13 @@
 /*
   The projects test aggregation of coverage reports from two sub-projects.
   The sub-projects are in the directories partA and partB.
-*/
+ */
 
 lazy val commonSettings = Seq(
   organization := "org.scoverage",
   version := "0.1.0",
-  scalaVersion := "2.12.13"
+  scalaVersion := "2.13.5"
 )
-
-lazy val specs2Lib = "org.specs2" %% "specs2" % "2.5" % "test"
 
 def module(name: String) = {
   val id = s"part$name"
@@ -17,7 +15,7 @@ def module(name: String) = {
     .settings(commonSettings: _*)
     .settings(
       Keys.name := name,
-      libraryDependencies += specs2Lib
+      libraryDependencies += "org.scalameta" %% "munit" % "0.7.25" % Test
     )
 }
 
@@ -25,16 +23,18 @@ lazy val partA = module("A")
 lazy val partB = module("B")
 
 lazy val root = (project in file("."))
-  .settings(commonSettings:_*)
+  .settings(commonSettings: _*)
   .settings(
     name := "root",
-    test := { }
-  ).aggregate(
+    test := {}
+  )
+  .aggregate(
     partA,
     partB
   )
 
 ThisBuild / resolvers ++= {
-  if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT"))) Seq(Resolver.sonatypeRepo("snapshots"))
+  if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
+    Seq(Resolver.sonatypeRepo("snapshots"))
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/aggregate/partA/src/test/scala/AdderTestSuite.scala
+++ b/src/sbt-test/scoverage/aggregate/partA/src/test/scala/AdderTestSuite.scala
@@ -1,13 +1,10 @@
-import org.specs2.mutable._
+import munit.FunSuite
 import org.scoverage.issue53.part.a.AdderScala
 
-/**
- * Created by Mikhail Kokho on 7/10/2015.
- */
-class AdderTestSuite extends Specification {
-  "Adder" should {
-    "sum two numbers" in {
-      AdderScala.add(1, 2) mustEqual 3
-    }
+/** Created by Mikhail Kokho on 7/10/2015.
+  */
+class AdderTestSuite extends FunSuite {
+  test("Adder should sum two numbers") {
+    assertEquals(AdderScala.add(1, 2), 3)
   }
 }

--- a/src/sbt-test/scoverage/aggregate/partB/src/test/scala/SubtractorTestSuite.scala
+++ b/src/sbt-test/scoverage/aggregate/partB/src/test/scala/SubtractorTestSuite.scala
@@ -1,14 +1,10 @@
-import org.specs2.mutable._
+import munit.FunSuite
 import org.scoverage.issue53.part.b.SubtractorScala
 
-/**
- * Created by Mikhail Kokho on 7/10/2015.
- */
-class SubtractorTestSuite extends Specification {
-  "Subtractor" should {
-    "subtract two numbers" in {
-      SubtractorScala.minus(2, 1) mustEqual 1
-    }
+/** Created by Mikhail Kokho on 7/10/2015.
+  */
+class SubtractorTestSuite extends FunSuite {
+  test("Subtractor should substract two numbers") {
+    assertEquals(SubtractorScala.minus(2, 1), 1)
   }
 }
-

--- a/src/sbt-test/scoverage/aggregate/test
+++ b/src/sbt-test/scoverage/aggregate/test
@@ -3,12 +3,12 @@
 > coverage
 > test
 # There should be scoverage-data directory
-$ exists partA/target/scala-2.12/scoverage-data
-$ exists partB/target/scala-2.12/scoverage-data
+$ exists partA/target/scala-2.13/scoverage-data
+$ exists partB/target/scala-2.13/scoverage-data
 > coverageReport
 # There should be scoverage-report directory
-$ exists partA/target/scala-2.12/scoverage-report
-$ exists partB/target/scala-2.12/scoverage-report
+$ exists partA/target/scala-2.13/scoverage-report
+$ exists partB/target/scala-2.13/scoverage-report
 > coverageAggregate
 # There should be a root scoverage-report directory
-$ exists target/scala-2.12/scoverage-report
+$ exists target/scala-2.13/scoverage-report

--- a/src/sbt-test/scoverage/bad-coverage/build.sbt
+++ b/src/sbt-test/scoverage/bad-coverage/build.sbt
@@ -1,14 +1,15 @@
 version := "0.1"
 
-scalaVersion := "2.12.13"
+scalaVersion := "2.13.5"
 
-libraryDependencies += "org.specs2" %% "specs2" % "2.5" % "test"
+libraryDependencies += "org.scalameta" %% "munit" % "0.7.25" % Test
 
 coverageMinimum := 80
 
 coverageFailOnMinimum := true
 
 resolvers ++= {
-  if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT"))) Seq(Resolver.sonatypeRepo("snapshots"))
+  if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
+    Seq(Resolver.sonatypeRepo("snapshots"))
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/bad-coverage/src/test/scala/BadCoverageSpec.scala
+++ b/src/sbt-test/scoverage/bad-coverage/src/test/scala/BadCoverageSpec.scala
@@ -1,13 +1,10 @@
-import org.specs2.mutable._
+import munit.FunSuite
 
-/**
- * Created by tbarke001c on 7/8/14.
- */
-class BadCoverageSpec extends Specification {
+/** Created by tbarke001c on 7/8/14.
+  */
+class BadCoverageSpec extends FunSuite {
 
-  "BadCoverage" should {
-    "sum two numbers" in {
-      BadCoverage.sum(1, 2) mustEqual 3
-    }
+  test("BadCoverage should sum two numbers") {
+    assertEquals(BadCoverage.sum(1, 2), 3)
   }
 }

--- a/src/sbt-test/scoverage/coverage-off/build.sbt
+++ b/src/sbt-test/scoverage/coverage-off/build.sbt
@@ -1,14 +1,15 @@
 version := "0.1"
 
-scalaVersion := "2.12.13"
+scalaVersion := "2.13.5"
 
-libraryDependencies += "org.specs2" %% "specs2" % "2.5" % "test"
+libraryDependencies += "org.scalameta" %% "munit" % "0.7.25" % Test
 
 coverageMinimum := 80
 
 coverageFailOnMinimum := true
 
 resolvers ++= {
-  if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT"))) Seq(Resolver.sonatypeRepo("snapshots"))
+  if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
+    Seq(Resolver.sonatypeRepo("snapshots"))
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/coverage-off/src/test/scala/GoodCoverageSpec.scala
+++ b/src/sbt-test/scoverage/coverage-off/src/test/scala/GoodCoverageSpec.scala
@@ -1,13 +1,10 @@
-import org.specs2.mutable._
+import munit.FunSuite
 
-/**
- * Created by tbarke001c on 7/8/14.
- */
-class GoodCoverageSpec extends Specification {
+/** Created by tbarke001c on 7/8/14.
+  */
+class GoodCoverageSpec extends FunSuite {
 
-  "GoodCoverage" should {
-    "sum two numbers" in {
-      GoodCoverage.sum(1, 2) mustEqual 3
-    }
+  test("GoodCoverage should sum two numvers") {
+    assertEquals(GoodCoverage.sum(1, 2), 3)
   }
 }

--- a/src/sbt-test/scoverage/good-coverage/build.sbt
+++ b/src/sbt-test/scoverage/good-coverage/build.sbt
@@ -1,14 +1,15 @@
 version := "0.1"
 
-scalaVersion := "2.12.13"
+scalaVersion := "2.13.5"
 
-libraryDependencies += "org.specs2" %% "specs2" % "2.5" % "test"
+libraryDependencies += "org.scalameta" %% "munit" % "0.7.25" % Test
 
 coverageMinimum := 80
 
 coverageFailOnMinimum := true
 
 resolvers ++= {
-  if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT"))) Seq(Resolver.sonatypeRepo("snapshots"))
+  if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
+    Seq(Resolver.sonatypeRepo("snapshots"))
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/good-coverage/src/test/scala/GoodCoverageSpec.scala
+++ b/src/sbt-test/scoverage/good-coverage/src/test/scala/GoodCoverageSpec.scala
@@ -1,13 +1,10 @@
-import org.specs2.mutable._
+import munit.FunSuite
 
-/**
- * Created by tbarke001c on 7/8/14.
- */
-class GoodCoverageSpec extends Specification {
+/** Created by tbarke001c on 7/8/14.
+  */
+class GoodCoverageSpec extends FunSuite {
 
-  "GoodCoverage" should {
-    "sum two numbers" in {
-      GoodCoverage.sum(1, 2) mustEqual 3
-    }
+  test("GoodCoverage should sum two numbers") {
+    assertEquals(GoodCoverage.sum(1, 2), 3)
   }
 }

--- a/src/sbt-test/scoverage/preserve-set/build.sbt
+++ b/src/sbt-test/scoverage/preserve-set/build.sbt
@@ -2,29 +2,39 @@ import sbt.complete.DefaultParsers._
 
 version := "0.1"
 
-scalaVersion := "2.12.13"
+scalaVersion := "2.13.5"
 
-crossScalaVersions := Seq("2.12.13")
+crossScalaVersions := Seq("2.13.5")
 
-libraryDependencies += "org.specs2" %% "specs2" % "2.5" % "test"
+libraryDependencies += "org.scalameta" %% "munit" % "0.7.25" % Test
 
-val checkScalaVersion = inputKey[Unit]("Input task to compare the value of scalaVersion setting with a given input.")
+val checkScalaVersion = inputKey[Unit](
+  "Input task to compare the value of scalaVersion setting with a given input."
+)
 checkScalaVersion := {
   val arg: String = (Space ~> StringBasic).parsed
-  if (scalaVersion.value != arg) sys.error(s"scalaVersion [${scalaVersion.value}] not equal to expected [$arg]")
+  if (scalaVersion.value != arg)
+    sys.error(
+      s"scalaVersion [${scalaVersion.value}] not equal to expected [$arg]"
+    )
   ()
 }
 
-val checkScoverageEnabled = inputKey[Unit]("Input task to compare the value of coverageEnabled setting with a given input.")
+val checkScoverageEnabled = inputKey[Unit](
+  "Input task to compare the value of coverageEnabled setting with a given input."
+)
 checkScoverageEnabled := {
   val arg: String = (Space ~> StringBasic).parsed
-  if (coverageEnabled.value.toString != arg) sys.error(s"coverageEnabled [${coverageEnabled.value}] not equal to expected [$arg]")
+  if (coverageEnabled.value.toString != arg)
+    sys.error(
+      s"coverageEnabled [${coverageEnabled.value}] not equal to expected [$arg]"
+    )
   ()
 }
 
-
 resolvers ++= {
-  if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT"))) Seq(Resolver.sonatypeRepo("snapshots"))
+  if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
+    Seq(Resolver.sonatypeRepo("snapshots"))
   else Seq.empty
 }
 

--- a/src/sbt-test/scoverage/preserve-set/src/test/scala/PreserveSetSpec.scala
+++ b/src/sbt-test/scoverage/preserve-set/src/test/scala/PreserveSetSpec.scala
@@ -1,10 +1,8 @@
-import org.specs2.mutable._
+import munit.FunSuite
 
-class PreserveSetSpec extends Specification {
+class PreserveSetSpec extends FunSuite {
 
-  "PreserveSet" should {
-    "sum two numbers" in {
-      PreserveSet.sum(1, 2) mustEqual 3
-    }
+  test("PreserveSet should sum two numbers") {
+    assertEquals(PreserveSet.sum(1, 2), 3)
   }
 }

--- a/src/sbt-test/scoverage/preserve-set/test
+++ b/src/sbt-test/scoverage/preserve-set/test
@@ -1,8 +1,8 @@
 # check scalaVersion setting
-> checkScalaVersion "2.12.13"
+> checkScalaVersion "2.13.5"
 > checkScoverageEnabled "false"
 > coverage
 > checkScoverageEnabled "true"
 > coverageOff
-> checkScalaVersion "2.12.13"
+> checkScalaVersion "2.13.5"
 > checkScoverageEnabled "false"

--- a/src/sbt-test/scoverage/scalac-plugin-version/build.sbt
+++ b/src/sbt-test/scoverage/scalac-plugin-version/build.sbt
@@ -5,10 +5,13 @@ lazy val root = (project in file(".")).settings(
 TaskKey[Unit]("check") := {
   assert(
     libraryDependencies.value.count(module =>
-      module.organization == "org.scoverage" && module.revision == "1.3.0") == 2)
+      module.organization == "org.scoverage" && module.revision == "1.3.0"
+    ) == 2
+  )
 }
 
 resolvers ++= {
-  if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT"))) Seq(Resolver.sonatypeRepo("snapshots"))
+  if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
+    Seq(Resolver.sonatypeRepo("snapshots"))
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/scalajs/build.sbt
+++ b/src/sbt-test/scoverage/scalajs/build.sbt
@@ -3,19 +3,19 @@ import sbtcrossproject.CrossType
 
 lazy val root = (project in file(".")).aggregate(crossJS, crossJVM)
 
-lazy val cross = CrossProject("sjstest", file("sjstest"))(JVMPlatform, JSPlatform)
-  .crossType(CrossType.Full)
-  .settings(
-    scalaVersion := "2.12.13",
-    libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "3.2.8" % "test"
+lazy val cross =
+  CrossProject("sjstest", file("sjstest"))(JVMPlatform, JSPlatform)
+    .crossType(CrossType.Full)
+    .settings(
+      scalaVersion := "2.13.5",
+      libraryDependencies += "org.scalameta" %% "munit" % "0.7.25" % Test
     )
-  )
 
 lazy val crossJS = cross.js
 lazy val crossJVM = cross.jvm
 
 ThisBuild / resolvers ++= {
-  if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT"))) Seq(Resolver.sonatypeRepo("snapshots"))
+  if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
+    Seq(Resolver.sonatypeRepo("snapshots"))
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/scalajs/sjstest/js/src/test/scala/JsTest.scala
+++ b/src/sbt-test/scoverage/scalajs/sjstest/js/src/test/scala/JsTest.scala
@@ -1,11 +1,9 @@
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
+import munit.FunSuite
 
-class JsTest extends AnyFlatSpec with Matchers {
+class JsTest extends FunSuite {
 
-  "JS UnderTest" should "work on JS" in {
-    UnderTest.jsMethod shouldBe "js"
+  test("JS UnderTest should work on JS") {
+    assertEquals(UnderTest.jsMethod, "js")
   }
 
 }
-

--- a/src/sbt-test/scoverage/scalajs/sjstest/jvm/src/test/scala/JvmTest.scala
+++ b/src/sbt-test/scoverage/scalajs/sjstest/jvm/src/test/scala/JvmTest.scala
@@ -1,11 +1,9 @@
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
+import munit.FunSuite
 
-class JvmTest extends AnyFlatSpec with Matchers {
+class JvmTest extends FunSuite {
 
-  "JVM UnderTest" should "work on JVM" in {
-    UnderTest.jvmMethod shouldBe "jvm"
+  test("JVM UnderTest work on JVM") {
+    assertEquals(UnderTest.jvmMethod, "jvm")
   }
 
 }
-

--- a/src/sbt-test/scoverage/scalajs/sjstest/shared/src/test/scala/SharedTest.scala
+++ b/src/sbt-test/scoverage/scalajs/sjstest/shared/src/test/scala/SharedTest.scala
@@ -1,10 +1,9 @@
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
+import munit.FunSuite
 
-class SharedTest extends AnyFlatSpec with Matchers {
+class SharedTest extends FunSuite {
 
-  "Shared UnderTest" should "return where it works" in {
-    UnderTest.onJsAndJvm shouldBe "js and jvm"
+  test("Shared UnderTest return where it works") {
+    assertEquals(UnderTest.onJsAndJvm, "js and jvm")
   }
 
 }

--- a/src/sbt-test/scoverage/scalajs/test
+++ b/src/sbt-test/scoverage/scalajs/test
@@ -3,9 +3,9 @@
 > coverage
 > test
 # There should be scoverage-data directory
-$ exists sjstest/js/target/scala-2.12/scoverage-data
-$ exists sjstest/jvm/target/scala-2.12/scoverage-data
+$ exists sjstest/js/target/scala-2.13/scoverage-data
+$ exists sjstest/jvm/target/scala-2.13/scoverage-data
 > coverageReport
 # There should be scoverage-report directory
-$ exists sjstest/js/target/scala-2.12/scoverage-report
-$ exists sjstest/jvm/target/scala-2.12/scoverage-report
+$ exists sjstest/js/target/scala-2.13/scoverage-report
+$ exists sjstest/jvm/target/scala-2.13/scoverage-report


### PR DESCRIPTION
Normally I wouldn't have updated these, but since specs2 changed
namespaces and I needed to go through and change everything since the
current one wasn't published for newer versions of Scala. Therefore I
just opted to migrate to a newer testframework that I do know will
continue to be supported. I also then bumped the Scala versions in the
actual tests.