### PR TITLE
Add in .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# It's a good idea to ignore the following commits from git blame.j
+# You can read more about this here if you're unfamiliar:
+# https://www.moxio.com/blog/43/ignoring-bulk-change-commits-with-git-blame
+#
+# Added scalafmt
+af2396558918fea00eaa2da12906a3012eb72153


### PR DESCRIPTION
Reformatting an entire project typically has the complaint that blame is
no longer useful. Thankfully, git has a solution for this. You can read
more about this here:

https://www.moxio.com/blog/43/ignoring-bulk-change-commits-with-git-blame

This `.git-blame-ignore-revs` file can be used to ensure that the
formatting commit is ignored when locally using `git blame.`