### PR TITLE
Ensure reporting and aggregation still works when disabling modules.

### DIFF
--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -170,9 +170,12 @@ object ScoverageSbtPlugin extends AutoPlugin {
     implicit val log = streams.value.log
     log.info(s"Aggregating coverage from subprojects...")
 
-    val dataDirs = coverageDataDir
-      .all(aggregateFilter)
-      .value map (_ / Constants.DataDir) filter (_.isDirectory)
+    val dataDirs = coverageDataDir.?.all(aggregateFilter).value
+      .collect {
+        case Some(file) if (file / Constants.DataDir).isDirectory =>
+          file / Constants.DataDir
+      }
+
     CoverageAggregator.aggregate(dataDirs) match {
       case Some(cov) =>
         writeReports(

--- a/src/sbt-test/scoverage/aggregate-disabled-module/a/src/main/scala/a/AdderScala.scala
+++ b/src/sbt-test/scoverage/aggregate-disabled-module/a/src/main/scala/a/AdderScala.scala
@@ -1,0 +1,7 @@
+package a
+
+object AdderScala {
+
+  def add(x: Int, y: Int) = x + y
+
+}

--- a/src/sbt-test/scoverage/aggregate-disabled-module/a/src/test/scala/AdderTestSuite.scala
+++ b/src/sbt-test/scoverage/aggregate-disabled-module/a/src/test/scala/AdderTestSuite.scala
@@ -1,0 +1,8 @@
+import munit.FunSuite
+import a.AdderScala
+
+class AdderTestSuite extends FunSuite {
+  test("Adder should sum two numbers") {
+    assertEquals(AdderScala.add(1, 2), 3)
+  }
+}

--- a/src/sbt-test/scoverage/aggregate-disabled-module/b/src/main/scala/b/AdderScala.scala
+++ b/src/sbt-test/scoverage/aggregate-disabled-module/b/src/main/scala/b/AdderScala.scala
@@ -1,0 +1,7 @@
+package b
+
+object AdderScala {
+
+  def add(x: Int, y: Int) = x + y
+
+}

--- a/src/sbt-test/scoverage/aggregate-disabled-module/b/src/test/scala/AdderTestSuite.scala
+++ b/src/sbt-test/scoverage/aggregate-disabled-module/b/src/test/scala/AdderTestSuite.scala
@@ -1,0 +1,8 @@
+import munit.FunSuite
+import b.AdderScala
+
+class AdderTestSuite extends FunSuite {
+  test("Adder should sum two numbers") {
+    assertEquals(AdderScala.add(1, 2), 3)
+  }
+}

--- a/src/sbt-test/scoverage/aggregate-disabled-module/build.sbt
+++ b/src/sbt-test/scoverage/aggregate-disabled-module/build.sbt
@@ -1,0 +1,17 @@
+inThisBuild(
+  List(
+    organization := "org.scoverage",
+    scalaVersion := "2.13.6",
+    libraryDependencies += "org.scalameta" %% "munit" % "0.7.25" % Test
+  )
+)
+
+lazy val a = project
+lazy val b = project
+lazy val c = project.disablePlugins(ScoverageSbtPlugin)
+
+ThisBuild / resolvers ++= {
+  if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
+    Seq(Resolver.sonatypeRepo("snapshots"))
+  else Seq.empty
+}

--- a/src/sbt-test/scoverage/aggregate-disabled-module/c/src/main/scala/c/AdderScala.scala
+++ b/src/sbt-test/scoverage/aggregate-disabled-module/c/src/main/scala/c/AdderScala.scala
@@ -1,0 +1,7 @@
+package c
+
+object AdderScala {
+
+  def add(x: Int, y: Int) = x + y
+
+}

--- a/src/sbt-test/scoverage/aggregate-disabled-module/c/src/test/scala/AdderTestSuite.scala
+++ b/src/sbt-test/scoverage/aggregate-disabled-module/c/src/test/scala/AdderTestSuite.scala
@@ -1,0 +1,8 @@
+import munit.FunSuite
+import c.AdderScala
+
+class AdderTestSuite extends FunSuite {
+  test("Adder should sum two numbers") {
+    assertEquals(AdderScala.add(1, 2), 3)
+  }
+}

--- a/src/sbt-test/scoverage/aggregate-disabled-module/project/build.properties
+++ b/src/sbt-test/scoverage/aggregate-disabled-module/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.5.5

--- a/src/sbt-test/scoverage/aggregate-disabled-module/project/plugins.sbt
+++ b/src/sbt-test/scoverage/aggregate-disabled-module/project/plugins.sbt
@@ -1,0 +1,16 @@
+val pluginVersion = sys.props.getOrElse(
+  "plugin.version",
+  throw new RuntimeException(
+    """|The system property 'plugin.version' is not defined.
+       |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+  )
+)
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % pluginVersion)
+
+resolvers ++= {
+  if (pluginVersion.endsWith("-SNAPSHOT"))
+    Seq(Resolver.sonatypeRepo("snapshots"))
+  else
+    Seq.empty
+}

--- a/src/sbt-test/scoverage/aggregate-disabled-module/test
+++ b/src/sbt-test/scoverage/aggregate-disabled-module/test
@@ -1,0 +1,16 @@
+# run scoverage using the coverage task
+> clean
+> coverage
+> test
+# There should be scoverage-data directory
+$ exists a/target/scala-2.13/scoverage-data
+$ exists b/target/scala-2.13/scoverage-data
+$ absent c/target/scala-2.13/scoverage-data
+> coverageReport
+# There should be scoverage-report directory
+$ exists a/target/scala-2.13/scoverage-report
+$ exists b/target/scala-2.13/scoverage-report
+$ absent c/target/scala-2.13/scoverage-report
+> coverageAggregate
+# There should be a root scoverage-report directory
+$ exists target/scala-2.13/scoverage-report


### PR DESCRIPTION
In the past reporting and aggregation would fail when you tried to
disable Scoverage for a specific module. This now will only take into
account the modules that have the keys defined rather than defaulting to
all of them.

Closes #376