### PR TITLE
Update Scalafmt to 3.1.2

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,1 +1,2 @@
-version = "3.0.8"
+version = "3.1.2"
+runner.dialect = scala212


### PR DESCRIPTION
Supersedes #397 

`runner.dialect` is needed since 3.1.0.
Ref: https://scalameta.org/scalafmt/docs/configuration.html#scala-dialects