### PR TITLE
feat: add support for 2.12.16 with newest scoverage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "sbt-scoverage"
 
 import sbt.ScriptedPlugin.autoImport.scriptedLaunchOpts
 
-lazy val scoverageVersion = "2.0.0-M5"
+lazy val scoverageVersion = "2.0.0-RC1"
 
 inThisBuild(
   List(

--- a/src/main/scala/scoverage/CoverageMinimum.scala
+++ b/src/main/scala/scoverage/CoverageMinimum.scala
@@ -86,11 +86,9 @@ object CoverageMinimum {
 
   def all = Def.setting {
     import ScoverageKeys._
-    val stmtTotal =
-      math.max(coverageMinimum.value, coverageMinimumStmtTotal.value)
     All(
       total = CoverageMinimum(
-        statement = stmtTotal,
+        statement = coverageMinimumStmtTotal.value,
         branch = coverageMinimumBranchTotal.value
       ),
       perPackage = CoverageMinimum(

--- a/src/main/scala/scoverage/ScoverageKeys.scala
+++ b/src/main/scala/scoverage/ScoverageKeys.scala
@@ -22,9 +22,6 @@ object ScoverageKeys {
   lazy val coverageSourceRoot = settingKey[File]("the source root of the project")
   // format: on
 
-  @deprecated("Use coverageMinimumStmtTotal instead", "v1.8.0")
-  lazy val coverageMinimum =
-    settingKey[Double]("see coverageMinimumStmtTotal")
   lazy val coverageMinimumStmtTotal =
     settingKey[Double]("scoverage minimum coverage: statement total")
   lazy val coverageMinimumBranchTotal =

--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -41,7 +41,6 @@ object ScoverageSbtPlugin extends AutoPlugin {
       coverageEnabled := false,
       coverageExcludedPackages := "",
       coverageExcludedFiles := "",
-      coverageMinimum := 0, // default is no minimum
       coverageMinimumStmtTotal := 0,
       coverageMinimumBranchTotal := 0,
       coverageMinimumStmtPerPackage := 0,

--- a/src/sbt-test/scoverage/bad-coverage/build.sbt
+++ b/src/sbt-test/scoverage/bad-coverage/build.sbt
@@ -4,7 +4,7 @@ scalaVersion := "2.13.6"
 
 libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
 
-coverageMinimum := 80
+coverageMinimumStmtTotal := 80
 
 coverageFailOnMinimum := true
 

--- a/src/sbt-test/scoverage/coverage-off/build.sbt
+++ b/src/sbt-test/scoverage/coverage-off/build.sbt
@@ -4,7 +4,6 @@ scalaVersion := "2.13.6"
 
 libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
 
-coverageMinimum := 80
 coverageMinimumStmtTotal := 100
 coverageMinimumBranchTotal := 100
 coverageMinimumStmtPerPackage := 100

--- a/src/sbt-test/scoverage/data-dir/build.sbt
+++ b/src/sbt-test/scoverage/data-dir/build.sbt
@@ -6,7 +6,7 @@ libraryDependencies += "org.specs2" %% "specs2-core" % "4.12.10" % "test"
 
 coverageDataDir := target.value / "custom-test"
 
-coverageMinimum := 80
+coverageMinimumStmtTotal := 80
 
 coverageFailOnMinimum := true
 

--- a/src/sbt-test/scoverage/good-coverage/build.sbt
+++ b/src/sbt-test/scoverage/good-coverage/build.sbt
@@ -4,7 +4,6 @@ scalaVersion := "2.13.6"
 
 libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
 
-coverageMinimum := 80
 coverageMinimumStmtTotal := 100
 coverageMinimumBranchTotal := 100
 coverageMinimumStmtPerPackage := 100

--- a/src/sbt-test/scoverage/scala3-bad/build.sbt
+++ b/src/sbt-test/scoverage/scala3-bad/build.sbt
@@ -4,7 +4,7 @@ scalaVersion := "3.2.0-RC1-bin-20220523-6783853-NIGHTLY" // TODO: Should be upda
 
 libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
 
-coverageMinimum := 80
+coverageMinimumStmtTotal := 80
 
 coverageFailOnMinimum := true
 

--- a/src/sbt-test/scoverage/scala3-good/build.sbt
+++ b/src/sbt-test/scoverage/scala3-good/build.sbt
@@ -4,7 +4,6 @@ scalaVersion := "3.2.0-RC1-bin-20220523-6783853-NIGHTLY" // TODO: Should be upda
 
 libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
 
-coverageMinimum := 80
 coverageMinimumStmtTotal := 100
 coverageMinimumBranchTotal := 100
 coverageMinimumStmtPerPackage := 100


### PR DESCRIPTION
This bumps the version of scoverage to the 2.0.0-RC1.

NOTE: That will this it also removes the long deprecated
`coverageMinimum`. You'll need to replace it with
`coverageMinimumStmtTotal`.