### PR TITLE
deps: update scoverage to 2.0.0-RC2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "sbt-scoverage"
 
 import sbt.ScriptedPlugin.autoImport.scriptedLaunchOpts
 
-lazy val scoverageVersion = "2.0.0-RC1"
+lazy val scoverageVersion = "2.0.0-RC2"
 
 inThisBuild(
   List(


### PR DESCRIPTION
This notably brings in support for the Scala native runtime.