### PR TITLE
Add coverageExclude task

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ false`.
 By default, scoverage will generate reports for each project separately. You can
 merge them into an aggregated report by using the following:
 
-```
+```bash
 $ sbt coverageAggregate
 ```
 
@@ -83,9 +83,6 @@ coverageExcludedFiles := ".*\\/two\\/GoodCoverage;.*\\/three\\/.*"
 
 Note: The `.scala` file extension needs to be omitted from the filename, if one is given.
 
-Note: These two options only work for Scala2. Right now Scala3 does not support
-a way to exclude packages or files from being instrumented.
-
 You can also mark sections of code with comments like:
 
 ```scala
@@ -96,6 +93,16 @@ You can also mark sections of code with comments like:
 
 Any code between two such comments will not be instrumented or included in the
 coverage report.
+
+Note: This only works for scala2. To make this work for scala3 you have to use
+the `coverageExclude` task.
+
+```bash
+$ sbt clean coverage test coverageExclude coverageReport
+```
+
+Note: This will take `excludedPackages` and `excludedFiles` into consideration,
+but not lines of code that are excluded with `COVERAGE-OFF/-ON`.
 
 ### Minimum coverage
 

--- a/src/main/scala/scoverage/ScoverageKeys.scala
+++ b/src/main/scala/scoverage/ScoverageKeys.scala
@@ -8,6 +8,7 @@ object ScoverageKeys {
     "controls whether code instrumentation is enabled or not"
   )
   lazy val coverageReport = taskKey[Unit]("run report generation")
+  lazy val coverageExclude = taskKey[Unit]("exclude/remove files and packages from coverage file (after the fact)")
   lazy val coverageAggregate = taskKey[Unit]("aggregate reports from subprojects")
   lazy val coverageExcludedPackages = settingKey[String]("regex for excluded packages")
   lazy val coverageExcludedFiles = settingKey[String]("regex for excluded file paths")

--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -13,7 +13,6 @@ import scoverage.reporter.ScoverageXmlWriter
 import scoverage.serialize.Serializer
 
 import java.time.Instant
-import scala.tools.nsc.reporters.NoReporter
 import scala.tools.nsc
 
 object ScoverageSbtPlugin extends AutoPlugin {

--- a/src/sbt-test/scoverage/scala3-coverage-excluded-files/test
+++ b/src/sbt-test/scoverage/scala3-coverage-excluded-files/test
@@ -2,8 +2,7 @@
 > clean
 > coverage
 > test
+> coverageExclude
 > coverageReport
 # There should be no directory for the excluded files
-#-$ exists target/scala-3.2.0-RC1/scoverage-report/two
-# But right now there is, because Scala3 does not support excluding files
-$ exists target/scala-3.2.0-RC1/scoverage-report/two
+-$ exists target/scala-3.2.0-RC1/scoverage-report/two


### PR DESCRIPTION
Hi @ckipp01,

this just shows/demos that and how the `coverageExclude` task works.

I know it is a "hack", but it is better than nothing and it works. I just tried it it on [nmesos](https://github.com/NinesStack/nmesos) ...

![image](https://user-images.githubusercontent.com/671381/177284284-46988d6c-a046-42ce-9d92-a35f9b5078c3.png)

I leave it with you to decide, if you want to consider this to include it in a potential 2.1.0 release.

Note: This also needs some minor changes to [scala-scoverage-plugin](https://github.com/scoverage/scalac-scoverage-plugin/pull/486)

Note: This PR builds on top of [this](https://github.com/scoverage/sbt-scoverage/pull/443) one.