### PR TITLE
Add sbt-vspp for publishing the SBT plug-in in a Maven-consistent format

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ In `project/plugins.sbt`:
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "x.x.x")
 ```
 
+If you are in an enterprise environment, and the above does not work, try:
+```scala
+libraryDependencies += "org.scoverage" % "sbt-scoverage_2.12_1.0" % "x.x.x"
+```
+
 ## Usage
 
 Run the tests with enabled coverage:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,3 +2,4 @@ libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+addSbtPlugin("com.scalawilliam.esbeetee" % "sbt-vspp" % "0.4.11")


### PR DESCRIPTION
Hi @ckipp01 - I hope it would not be too much trouble to include this to your plug-in!

This is to enable usage of sbt-scoverage in Enterprise environments where only the valid-POM format is accepted for JAR downloads, enabling it for many teams to move from Gradle/Maven to SBT for their Scala (and even non-Scala projects).

The only change this does is to add extra JAR and POM to the artifact (while keeping the old structure -- and also enabling listing of this project on e.g. [mvnrepository.com](https://mvnrepository.com/artifact/com.scalawilliam.esbeetee/sbt-vspp_2.12_1.0))

More background here: https://github.com/esbeetee/sbt-vspp/blob/main/README.md
