### PR TITLE
chore: make it clearer that the user should update to 3.2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ sbt-scoverage is an sbt plugin that offers support for Scala code coverage using
 [scoverage](https://github.com/scoverage/scalac-scoverage-plugin). This plugin
 supports Scala 2.12, 2.13, and 3.
 
-*NOTE*: that ScalaJS and Scala Native support is limited to Scala 2.
+**NOTE**: that ScalaJS and Scala Native support is limited to Scala 2.
+**NOTE**: that Scala 3 support starts with 3.2.x.
+
 
 ## Setup
 

--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -110,6 +110,9 @@ object ScoverageSbtPlugin extends AutoPlugin {
 
   private lazy val scalacSettings = Seq(
     Compile / compile / scalacOptions ++= {
+
+      implicit val log = streams.value.log
+
       val updateReport = update.value
       if (coverageEnabled.value && isScala2(scalaVersion.value)) {
         val scoverageDeps: Seq[File] =
@@ -168,6 +171,11 @@ object ScoverageSbtPlugin extends AutoPlugin {
         Seq(
           s"-coverage-out:${coverageDataDir.value.getAbsolutePath()}/scoverage-data"
         )
+      } else if (coverageEnabled.value && !isScala2(scalaVersion.value)) {
+        log.warn(
+          "coverage in Scala 3 needs at lease 3.2.x. Please update your Scala version and try again."
+        )
+        Nil
       } else {
         Nil
       }


### PR DESCRIPTION
Right now there isn't a lot of support if you try to use coverage under
3.1.x for example. This will show you a warning that you need to update to
3.2.x if you try with a Scala 3 version that isn't new enough.