### PR TITLE
Fix typo on Scala version check

### DIFF
--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -173,7 +173,7 @@ object ScoverageSbtPlugin extends AutoPlugin {
         )
       } else if (coverageEnabled.value && !isScala2(scalaVersion.value)) {
         log.warn(
-          "coverage in Scala 3 needs at lease 3.2.x. Please update your Scala version and try again."
+          "coverage in Scala 3 needs at least 3.2.x. Please update your Scala version and try again."
         )
         Nil
       } else {


### PR DESCRIPTION
Just fixes a small typo on the Scala 3.2.x warning.