### PR TITLE
chore: bump default scoverage version to 2.0.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "sbt-scoverage"
 
 import sbt.ScriptedPlugin.autoImport.scriptedLaunchOpts
 
-lazy val scoverageVersion = "2.0.10"
+lazy val scoverageVersion = "2.0.11"
 
 inThisBuild(
   List(


### PR DESCRIPTION
This is mainly to add in support for 2.13.12.
