### PR TITLE
chore: bump default scoverage to 2.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "sbt-scoverage"
 
 import sbt.ScriptedPlugin.autoImport.scriptedLaunchOpts
 
-lazy val scoverageVersion = "2.0.11"
+lazy val scoverageVersion = "2.1.0"
 
 inThisBuild(
   List(
@@ -25,7 +25,7 @@ inThisBuild(
     licenses := Seq(
       "Apache-2.0" -> url("http://www.apache.org/license/LICENSE-2.0")
     ),
-    scalaVersion := "2.12.15"
+    scalaVersion := "2.12.19"
   )
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.9.9

--- a/src/sbt-test/scoverage/aggregate-disabled-module/build.sbt
+++ b/src/sbt-test/scoverage/aggregate-disabled-module/build.sbt
@@ -1,7 +1,7 @@
 inThisBuild(
   List(
     organization := "org.scoverage",
-    scalaVersion := "2.13.6",
+    scalaVersion := "2.13.13",
     libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
   )
 )

--- a/src/sbt-test/scoverage/aggregate-disabled-module/project/build.properties
+++ b/src/sbt-test/scoverage/aggregate-disabled-module/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.9.0

--- a/src/sbt-test/scoverage/aggregate-only/build.sbt
+++ b/src/sbt-test/scoverage/aggregate-only/build.sbt
@@ -6,7 +6,7 @@
 lazy val commonSettings = Seq(
   organization := "org.scoverage",
   version := "0.1.0",
-  scalaVersion := "2.13.6"
+  scalaVersion := "2.13.13"
 )
 
 def module(name: String) = {

--- a/src/sbt-test/scoverage/aggregate/build.sbt
+++ b/src/sbt-test/scoverage/aggregate/build.sbt
@@ -6,7 +6,7 @@
 lazy val commonSettings = Seq(
   organization := "org.scoverage",
   version := "0.1.0",
-  scalaVersion := "2.13.6"
+  scalaVersion := "2.13.13"
 )
 
 def module(name: String) = {

--- a/src/sbt-test/scoverage/aggregate/project/build.properties
+++ b/src/sbt-test/scoverage/aggregate/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.9.9

--- a/src/sbt-test/scoverage/bad-coverage-file-branch/build.sbt
+++ b/src/sbt-test/scoverage/bad-coverage-file-branch/build.sbt
@@ -1,6 +1,6 @@
 version := "0.1"
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.13"
 
 libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
 

--- a/src/sbt-test/scoverage/bad-coverage-file-stmt/build.sbt
+++ b/src/sbt-test/scoverage/bad-coverage-file-stmt/build.sbt
@@ -1,6 +1,6 @@
 version := "0.1"
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.13"
 
 libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
 

--- a/src/sbt-test/scoverage/bad-coverage-package-branch/build.sbt
+++ b/src/sbt-test/scoverage/bad-coverage-package-branch/build.sbt
@@ -1,6 +1,6 @@
 version := "0.1"
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.13"
 
 libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
 

--- a/src/sbt-test/scoverage/bad-coverage-package-stmt/build.sbt
+++ b/src/sbt-test/scoverage/bad-coverage-package-stmt/build.sbt
@@ -1,6 +1,6 @@
 version := "0.1"
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.13"
 
 libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
 

--- a/src/sbt-test/scoverage/bad-coverage-total-branch/build.sbt
+++ b/src/sbt-test/scoverage/bad-coverage-total-branch/build.sbt
@@ -1,6 +1,6 @@
 version := "0.1"
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.13"
 
 libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
 

--- a/src/sbt-test/scoverage/bad-coverage-total-stmt/build.sbt
+++ b/src/sbt-test/scoverage/bad-coverage-total-stmt/build.sbt
@@ -1,6 +1,6 @@
 version := "0.1"
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.13"
 
 libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
 

--- a/src/sbt-test/scoverage/bad-coverage/build.sbt
+++ b/src/sbt-test/scoverage/bad-coverage/build.sbt
@@ -1,6 +1,6 @@
 version := "0.1"
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.13"
 
 libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
 

--- a/src/sbt-test/scoverage/coverage-excluded-files/build.sbt
+++ b/src/sbt-test/scoverage/coverage-excluded-files/build.sbt
@@ -1,6 +1,6 @@
 version := "0.1"
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.13"
 
 libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
 

--- a/src/sbt-test/scoverage/coverage-excluded-files/project/build.properties
+++ b/src/sbt-test/scoverage/coverage-excluded-files/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.9.9

--- a/src/sbt-test/scoverage/coverage-excluded-packages/build.sbt
+++ b/src/sbt-test/scoverage/coverage-excluded-packages/build.sbt
@@ -1,6 +1,6 @@
 version := "0.1"
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.13"
 
 libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
 

--- a/src/sbt-test/scoverage/coverage-excluded-packages/project/build.properties
+++ b/src/sbt-test/scoverage/coverage-excluded-packages/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.9.9

--- a/src/sbt-test/scoverage/coverage-off/build.sbt
+++ b/src/sbt-test/scoverage/coverage-off/build.sbt
@@ -1,6 +1,6 @@
 version := "0.1"
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.13"
 
 libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
 

--- a/src/sbt-test/scoverage/coverage-off/project/build.properties
+++ b/src/sbt-test/scoverage/coverage-off/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.9.9

--- a/src/sbt-test/scoverage/data-dir/build.sbt
+++ b/src/sbt-test/scoverage/data-dir/build.sbt
@@ -1,6 +1,6 @@
 version := "0.1"
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.13"
 
 libraryDependencies += "org.specs2" %% "specs2-core" % "4.12.10" % "test"
 

--- a/src/sbt-test/scoverage/data-dir/project/build.properties
+++ b/src/sbt-test/scoverage/data-dir/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.3
+sbt.version=1.9.9

--- a/src/sbt-test/scoverage/good-coverage/build.sbt
+++ b/src/sbt-test/scoverage/good-coverage/build.sbt
@@ -1,6 +1,6 @@
 version := "0.1"
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.13"
 
 libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
 

--- a/src/sbt-test/scoverage/preserve-set/build.sbt
+++ b/src/sbt-test/scoverage/preserve-set/build.sbt
@@ -2,9 +2,9 @@ import sbt.complete.DefaultParsers._
 
 version := "0.1"
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.13"
 
-crossScalaVersions := Seq("2.13.6")
+crossScalaVersions := Seq("2.13.13")
 
 libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
 

--- a/src/sbt-test/scoverage/preserve-set/test
+++ b/src/sbt-test/scoverage/preserve-set/test
@@ -1,8 +1,8 @@
 # check scalaVersion setting
-> checkScalaVersion "2.13.6"
+> checkScalaVersion "2.13.13"
 > checkScoverageEnabled "false"
 > coverage
 > checkScoverageEnabled "true"
 > coverageOff
-> checkScalaVersion "2.13.6"
+> checkScalaVersion "2.13.13"
 > checkScoverageEnabled "false"

--- a/src/sbt-test/scoverage/scala3-coverage-excluded-files/project/build.properties
+++ b/src/sbt-test/scoverage/scala3-coverage-excluded-files/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.9.9


### PR DESCRIPTION
This adds in support to 2.12.19 and 2.13.13