### PR TITLE
Make scripted tests more comprehensive

### DIFF
--- a/src/sbt-test/scoverage/aggregate-disabled-module/build.sbt
+++ b/src/sbt-test/scoverage/aggregate-disabled-module/build.sbt
@@ -12,6 +12,6 @@ lazy val c = project.disablePlugins(ScoverageSbtPlugin)
 
 ThisBuild / resolvers ++= {
   if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
-    Seq(Resolver.sonatypeRepo("snapshots"))
+    Resolver.sonatypeOssRepos("snapshots")
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/aggregate-only/build.sbt
+++ b/src/sbt-test/scoverage/aggregate-only/build.sbt
@@ -35,6 +35,6 @@ lazy val root = (project in file("."))
 
 ThisBuild / resolvers ++= {
   if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
-    Seq(Resolver.sonatypeRepo("snapshots"))
+    Resolver.sonatypeOssRepos("snapshots")
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/aggregate/build.sbt
+++ b/src/sbt-test/scoverage/aggregate/build.sbt
@@ -35,6 +35,6 @@ lazy val root = (project in file("."))
 
 ThisBuild / resolvers ++= {
   if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
-    Seq(Resolver.sonatypeRepo("snapshots"))
+    Resolver.sonatypeOssRepos("snapshots")
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/bad-coverage-file-branch/build.sbt
+++ b/src/sbt-test/scoverage/bad-coverage-file-branch/build.sbt
@@ -14,6 +14,6 @@ resolvers ++= {
       .get("plugin.version")
       .map(_.endsWith("-SNAPSHOT"))
       .getOrElse(false)
-  ) Seq(Resolver.sonatypeRepo("snapshots"))
+  ) Resolver.sonatypeOssRepos("snapshots")
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/bad-coverage-file-stmt/build.sbt
+++ b/src/sbt-test/scoverage/bad-coverage-file-stmt/build.sbt
@@ -14,6 +14,6 @@ resolvers ++= {
       .get("plugin.version")
       .map(_.endsWith("-SNAPSHOT"))
       .getOrElse(false)
-  ) Seq(Resolver.sonatypeRepo("snapshots"))
+  ) Resolver.sonatypeOssRepos("snapshots")
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/bad-coverage-package-branch/build.sbt
+++ b/src/sbt-test/scoverage/bad-coverage-package-branch/build.sbt
@@ -14,6 +14,6 @@ resolvers ++= {
       .get("plugin.version")
       .map(_.endsWith("-SNAPSHOT"))
       .getOrElse(false)
-  ) Seq(Resolver.sonatypeRepo("snapshots"))
+  ) Resolver.sonatypeOssRepos("snapshots")
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/bad-coverage-package-stmt/build.sbt
+++ b/src/sbt-test/scoverage/bad-coverage-package-stmt/build.sbt
@@ -14,6 +14,6 @@ resolvers ++= {
       .get("plugin.version")
       .map(_.endsWith("-SNAPSHOT"))
       .getOrElse(false)
-  ) Seq(Resolver.sonatypeRepo("snapshots"))
+  ) Resolver.sonatypeOssRepos("snapshots")
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/bad-coverage-total-branch/build.sbt
+++ b/src/sbt-test/scoverage/bad-coverage-total-branch/build.sbt
@@ -14,6 +14,6 @@ resolvers ++= {
       .get("plugin.version")
       .map(_.endsWith("-SNAPSHOT"))
       .getOrElse(false)
-  ) Seq(Resolver.sonatypeRepo("snapshots"))
+  ) Resolver.sonatypeOssRepos("snapshots")
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/bad-coverage-total-stmt/build.sbt
+++ b/src/sbt-test/scoverage/bad-coverage-total-stmt/build.sbt
@@ -14,6 +14,6 @@ resolvers ++= {
       .get("plugin.version")
       .map(_.endsWith("-SNAPSHOT"))
       .getOrElse(false)
-  ) Seq(Resolver.sonatypeRepo("snapshots"))
+  ) Resolver.sonatypeOssRepos("snapshots")
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/bad-coverage/build.sbt
+++ b/src/sbt-test/scoverage/bad-coverage/build.sbt
@@ -10,6 +10,6 @@ coverageFailOnMinimum := true
 
 resolvers ++= {
   if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
-    Seq(Resolver.sonatypeRepo("snapshots"))
+    Resolver.sonatypeOssRepos("snapshots")
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/coverage-excluded-files/build.sbt
+++ b/src/sbt-test/scoverage/coverage-excluded-files/build.sbt
@@ -4,10 +4,10 @@ scalaVersion := "2.13.13"
 
 libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
 
-coverageExcludedFiles := ".*/two/GoodCoverage"
+coverageExcludedFiles := ".*\\/two\\/GoodCoverage;.*\\/three\\/.*"
 
 resolvers ++= {
   if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
-    Seq(Resolver.sonatypeRepo("snapshots"))
+    Resolver.sonatypeOssRepos("snapshots")
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/coverage-excluded-files/test
+++ b/src/sbt-test/scoverage/coverage-excluded-files/test
@@ -4,4 +4,6 @@
 > test
 > coverageReport
 # There should be no directory for the excluded files
+$ exists target/scala-2.13/scoverage-report/GoodCoverage.scala.html
 -$ exists target/scala-2.13/scoverage-report/two
+-$ exists target/scala-2.13/scoverage-report/three

--- a/src/sbt-test/scoverage/coverage-excluded-packages/build.sbt
+++ b/src/sbt-test/scoverage/coverage-excluded-packages/build.sbt
@@ -4,10 +4,10 @@ scalaVersion := "2.13.13"
 
 libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
 
-coverageExcludedPackages := "two\\..*"
+coverageExcludedPackages := "two\\..*;three\\..*"
 
 resolvers ++= {
   if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
-    Seq(Resolver.sonatypeRepo("snapshots"))
+    Resolver.sonatypeOssRepos("snapshots")
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/coverage-excluded-packages/test
+++ b/src/sbt-test/scoverage/coverage-excluded-packages/test
@@ -4,4 +4,6 @@
 > test
 > coverageReport
 # There should be no directory for the excluded package
+$ exists target/scala-2.13/scoverage-report/GoodCoverage.scala.html
 -$ exists target/scala-2.13/scoverage-report/two
+-$ exists target/scala-2.13/scoverage-report/three

--- a/src/sbt-test/scoverage/coverage-off/build.sbt
+++ b/src/sbt-test/scoverage/coverage-off/build.sbt
@@ -15,6 +15,6 @@ coverageFailOnMinimum := true
 
 resolvers ++= {
   if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
-    Seq(Resolver.sonatypeRepo("snapshots"))
+    Resolver.sonatypeOssRepos("snapshots")
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/data-dir/build.sbt
+++ b/src/sbt-test/scoverage/data-dir/build.sbt
@@ -12,6 +12,6 @@ coverageFailOnMinimum := true
 
 resolvers ++= {
   if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
-    Seq(Resolver.sonatypeRepo("snapshots"))
+    Resolver.sonatypeOssRepos("snapshots")
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/good-coverage/build.sbt
+++ b/src/sbt-test/scoverage/good-coverage/build.sbt
@@ -15,6 +15,6 @@ coverageFailOnMinimum := true
 
 resolvers ++= {
   if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
-    Seq(Resolver.sonatypeRepo("snapshots"))
+    Resolver.sonatypeOssRepos("snapshots")
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/preserve-set/build.sbt
+++ b/src/sbt-test/scoverage/preserve-set/build.sbt
@@ -34,7 +34,7 @@ checkScoverageEnabled := {
 
 resolvers ++= {
   if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
-    Seq(Resolver.sonatypeRepo("snapshots"))
+    Resolver.sonatypeOssRepos("snapshots")
   else Seq.empty
 }
 

--- a/src/sbt-test/scoverage/scala3-bad/build.sbt
+++ b/src/sbt-test/scoverage/scala3-bad/build.sbt
@@ -12,6 +12,6 @@ coverageEnabled := true
 
 resolvers ++= {
   if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
-    Seq(Resolver.sonatypeRepo("snapshots"))
+    Resolver.sonatypeOssRepos("snapshots")
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/scala3-coverage-excluded-files/build.sbt
+++ b/src/sbt-test/scoverage/scala3-coverage-excluded-files/build.sbt
@@ -4,10 +4,10 @@ scalaVersion := "3.4.2"
 
 libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
 
-coverageExcludedFiles := ".*/two/GoodCoverage;.*/three/GoodCoverage"
+coverageExcludedFiles := ".*\\/two\\/GoodCoverage;.*\\/three\\/.*"
 
 resolvers ++= {
   if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
-    Seq(Resolver.sonatypeRepo("snapshots"))
+    Resolver.sonatypeOssRepos("snapshots")
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/scala3-coverage-excluded-files/test
+++ b/src/sbt-test/scoverage/scala3-coverage-excluded-files/test
@@ -4,4 +4,6 @@
 > test
 > coverageReport
 # There should be no directory for the excluded files
+$ exists target/scala-3.4.2/scoverage-report/GoodCoverage.scala.html
 -$ exists target/scala-3.4.2/scoverage-report/two
+-$ exists target/scala-3.4.2/scoverage-report/three

--- a/src/sbt-test/scoverage/scala3-coverage-excluded-packages/build.sbt
+++ b/src/sbt-test/scoverage/scala3-coverage-excluded-packages/build.sbt
@@ -8,6 +8,6 @@ coverageExcludedPackages := "two\\..*;three\\..*"
 
 resolvers ++= {
   if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
-    Seq(Resolver.sonatypeRepo("snapshots"))
+    Resolver.sonatypeOssRepos("snapshots")
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/scala3-coverage-excluded-packages/test
+++ b/src/sbt-test/scoverage/scala3-coverage-excluded-packages/test
@@ -4,4 +4,6 @@
 > test
 > coverageReport
 # There should be no directory for the excluded package
+$ exists target/scala-3.4.2/scoverage-report/GoodCoverage.scala.html
 -$ exists target/scala-3.4.2/scoverage-report/two
+-$ exists target/scala-3.4.2/scoverage-report/three

--- a/src/sbt-test/scoverage/scala3-good/build.sbt
+++ b/src/sbt-test/scoverage/scala3-good/build.sbt
@@ -15,6 +15,6 @@ coverageFailOnMinimum := true
 
 resolvers ++= {
   if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
-    Seq(Resolver.sonatypeRepo("snapshots"))
+    Resolver.sonatypeOssRepos("snapshots")
   else Seq.empty
 }

--- a/src/sbt-test/scoverage/scalajs/build.sbt
+++ b/src/sbt-test/scoverage/scalajs/build.sbt
@@ -16,6 +16,6 @@ lazy val crossJVM = cross.jvm
 
 ThisBuild / resolvers ++= {
   if (sys.props.get("plugin.version").exists(_.endsWith("-SNAPSHOT")))
-    Seq(Resolver.sonatypeRepo("snapshots"))
+    Resolver.sonatypeOssRepos("snapshots")
   else Seq.empty
 }


### PR DESCRIPTION
This PR ...

* makes sure that the exclude tests test for the exclusion of multiple files
* do not only test for exclusion but also for inclusion (`GoodCoverage.scala.html` needs to be there)
* fixes the `sonatypeRepo is deprecated` warning