### PR TITLE
Make sure we support patch versions larger than 9

### DIFF
--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -89,14 +89,13 @@ object ScoverageSbtPlugin extends AutoPlugin {
       }
 
   private def isScala3SupportingFilePackageExclusion(scalaVersion: String) = {
-    def patch = scalaVersion.split('.').drop(2).headOption
+    def patch = scalaVersion.split('.').map(_.toInt).drop(2).headOption
     CrossVersion
       .partialVersion(scalaVersion)
       .exists {
-        case (3, minor)
-            if minor > 4 || (minor == 4 && patch.exists(_ >= "2")) =>
-          true
-        case _ => false
+        case (3, minor) if minor > 4                            => true
+        case (3, minor) if (minor == 4 && patch.exists(_ >= 2)) => true
+        case _                                                  => false
       }
   }
 

--- a/src/sbt-test/scoverage/scala3-coverage-excluded-files/build.sbt
+++ b/src/sbt-test/scoverage/scala3-coverage-excluded-files/build.sbt
@@ -1,6 +1,6 @@
 version := "0.1"
 
-scalaVersion := "3.4.2"
+scalaVersion := "3.5.0"
 
 libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
 

--- a/src/sbt-test/scoverage/scala3-coverage-excluded-files/test
+++ b/src/sbt-test/scoverage/scala3-coverage-excluded-files/test
@@ -4,6 +4,6 @@
 > test
 > coverageReport
 # There should be no directory for the excluded files
-$ exists target/scala-3.4.2/scoverage-report/GoodCoverage.scala.html
--$ exists target/scala-3.4.2/scoverage-report/two
--$ exists target/scala-3.4.2/scoverage-report/three
+$ exists target/scala-3.5.0/scoverage-report/GoodCoverage.scala.html
+-$ exists target/scala-3.5.0/scoverage-report/two
+-$ exists target/scala-3.5.0/scoverage-report/three


### PR DESCRIPTION
Minor bug fix ...

- to make patch versions larger 9 work the patch version needs to be an int
- also ... upgrade the excludeFilePackages test to 3.5.0