### PR TITLE
Ensure the data dir uses platform specific path separators

### DIFF
--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -175,7 +175,7 @@ object ScoverageSbtPlugin extends AutoPlugin {
             s"-Xplugin:${pluginPaths.mkString(java.io.File.pathSeparator)}"
           ),
           Some(
-            s"-P:scoverage:dataDir:${coverageDataDir.value.getAbsolutePath}/scoverage-data"
+            s"-P:scoverage:dataDir:${new java.io.File(coverageDataDir.value, "scoverage-data").getAbsolutePath}"
           ),
           Some(
             s"-P:scoverage:sourceRoot:${coverageSourceRoot.value.getAbsolutePath}"
@@ -191,7 +191,7 @@ object ScoverageSbtPlugin extends AutoPlugin {
       ) {
         Seq(
           Some(
-            s"-coverage-out:${coverageDataDir.value.getAbsolutePath()}/scoverage-data"
+            s"-coverage-out:${new java.io.File(coverageDataDir.value, "scoverage-data").getAbsolutePath}"
           ),
           excludedPackages
             .collect {


### PR DESCRIPTION
Hi!

While working with the `scalac-options` in our plugin, I noticed that `sbt-scoverage` uses a fixed path separator for the value of `scoverage:dataDir` parameter. It introduces the need to have an additional normalization logic, that might be problematic in some cases. This patch changes the way how `scoverage:dataDir` and `-coverage-out` are created to ensure that the resulting path uses platform-specific path separators.